### PR TITLE
Add socket pipeline support for host Gazebo proxy

### DIFF
--- a/bv_core/detectors/__init__.py
+++ b/bv_core/detectors/__init__.py
@@ -1,15 +1,37 @@
 """Pluggable object detection backends."""
 
+from typing import TYPE_CHECKING
+
 from .base_detector import BaseDetector
-from .gazebo_bbox_detector import GazeboBBoxDetector
-from .ml_detector import MLDetector
+
+if TYPE_CHECKING:
+    from .gazebo_bbox_detector import GazeboBBoxDetector
+    from .ml_detector import MLDetector
+    from .socket_bbox_detector import SocketBBoxDetector
 
 __all__ = [
     "BaseDetector",
     "GazeboBBoxDetector",
     "MLDetector",
+    "SocketBBoxDetector",
     "create_detector",
 ]
+
+
+def __getattr__(name: str):
+    if name == "GazeboBBoxDetector":
+        from .gazebo_bbox_detector import GazeboBBoxDetector
+
+        return GazeboBBoxDetector
+    if name == "MLDetector":
+        from .ml_detector import MLDetector
+
+        return MLDetector
+    if name == "SocketBBoxDetector":
+        from .socket_bbox_detector import SocketBBoxDetector
+
+        return SocketBBoxDetector
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def create_detector(detector_type: str, **config) -> BaseDetector:
@@ -19,6 +41,7 @@ def create_detector(detector_type: str, **config) -> BaseDetector:
         detector_type: Type of detector to create. Options:
             - "ml": ML-based detector using RF-DETR
             - "gazebo_bbox": Gazebo bounding box camera detector
+            - "socket_bbox": Host proxy detector that receives Gazebo bbox messages
         **config: Configuration parameters passed to the detector constructor.
 
     Returns:
@@ -28,17 +51,29 @@ def create_detector(detector_type: str, **config) -> BaseDetector:
         ValueError: If detector_type is unknown.
     """
     if detector_type == "ml":
+        from .ml_detector import MLDetector
+
         return MLDetector(
             batch_size=config.get("batch_size", 16),
             resolution=config.get("resolution", 728),
         )
     elif detector_type == "gazebo_bbox":
+        from .gazebo_bbox_detector import GazeboBBoxDetector
+
         return GazeboBBoxDetector(
             topic=config.get("gazebo_bbox_topic", "/camera/bounding_boxes"),
+            queue_size=config.get("queue_size", 5),
+        )
+    elif detector_type == "socket_bbox":
+        from .socket_bbox_detector import SocketBBoxDetector
+
+        return SocketBBoxDetector(
+            host=config.get("socket_host", "127.0.0.1"),
+            port=int(config.get("socket_port", 37031)),
             queue_size=config.get("queue_size", 5),
         )
     else:
         raise ValueError(
             f"Unknown detector type: '{detector_type}'. "
-            f"Valid options: 'ml', 'gazebo_bbox'"
+            f"Valid options: 'ml', 'gazebo_bbox', 'socket_bbox'"
         )

--- a/bv_core/detectors/base_detector.py
+++ b/bv_core/detectors/base_detector.py
@@ -1,9 +1,12 @@
 """Abstract interface for object detection backends."""
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
-import supervision as sv
+
+if TYPE_CHECKING:
+    import supervision as sv
 
 
 class BaseDetector(ABC):
@@ -24,7 +27,7 @@ class BaseDetector(ABC):
         pass
 
     @abstractmethod
-    def process_frame(self, frame: np.ndarray, **kwargs) -> sv.Detections:
+    def process_frame(self, frame: np.ndarray, **kwargs) -> "sv.Detections":
         """Run detection on a frame.
 
         Args:

--- a/bv_core/detectors/socket_bbox_detector.py
+++ b/bv_core/detectors/socket_bbox_detector.py
@@ -1,0 +1,136 @@
+"""Socket-fed detector that consumes proxied Gazebo bbox messages."""
+
+import queue
+import threading
+
+import numpy as np
+import rclpy.logging
+import supervision as sv
+
+from ..socket_proxy_client import SocketProxySubscriber
+from .base_detector import BaseDetector
+from .gazebo_bbox_detector import GAZEBO_LABEL_TO_COCO
+
+
+class SocketBBoxDetector(BaseDetector):
+    """Detector that reads bbox payloads from the host proxy instead of Gazebo."""
+
+    def __init__(self, host: str, port: int, queue_size: int = 5):
+        self._host = host
+        self._port = port
+        self._queue_size = queue_size
+        self._running = False
+        self._bbox_queue = queue.Queue(maxsize=queue_size)
+        self._lock = threading.Lock()
+        self._subscriber = SocketProxySubscriber(
+            host=host,
+            port=port,
+            kind="bbox",
+            on_message=self._handle_bbox_msg,
+            logger_name="socket_bbox_detector",
+        )
+
+    def start(self) -> None:
+        if self._running:
+            return
+
+        self._subscriber.start()
+        self._running = True
+        rclpy.logging.get_logger("socket_bbox_detector").info(
+            f"Connected bbox detector to host proxy {self._host}:{self._port}"
+        )
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+
+        self._subscriber.stop()
+        self._running = False
+        self._clear_queue()
+
+    def process_frame(self, frame: np.ndarray, **kwargs) -> sv.Detections:
+        if not self._running:
+            rclpy.logging.get_logger("socket_bbox_detector").warning(
+                "Detector not started"
+            )
+            return sv.Detections.empty()
+
+        bbox_msg = self._get_latest_bbox()
+        if bbox_msg is None:
+            return sv.Detections.empty()
+
+        return self._msg_to_detections(bbox_msg, frame.shape)
+
+    def _handle_bbox_msg(self, msg: dict) -> None:
+        if not self._running:
+            return
+
+        with self._lock:
+            if self._bbox_queue.full():
+                try:
+                    self._bbox_queue.get_nowait()
+                except queue.Empty:
+                    pass
+            self._bbox_queue.put_nowait(msg)
+
+    def _get_latest_bbox(self) -> dict | None:
+        latest = None
+        with self._lock:
+            while True:
+                try:
+                    latest = self._bbox_queue.get_nowait()
+                except queue.Empty:
+                    break
+        return latest
+
+    def _clear_queue(self) -> None:
+        with self._lock:
+            while True:
+                try:
+                    self._bbox_queue.get_nowait()
+                except queue.Empty:
+                    break
+
+    def _msg_to_detections(
+        self,
+        msg: dict,
+        frame_shape: tuple,
+    ) -> sv.Detections:
+        boxes = msg.get("detections") or []
+        if not boxes:
+            return sv.Detections.empty()
+
+        height, width = frame_shape[:2]
+        xyxy_list = []
+        class_ids = []
+        confidences = []
+
+        for box in boxes:
+            gazebo_label = int(box.get("label", 0))
+            coco_class_id = GAZEBO_LABEL_TO_COCO.get(gazebo_label, 0)
+
+            x_min = float(box.get("xmin", 0.0))
+            y_min = float(box.get("ymin", 0.0))
+            x_max = float(box.get("xmax", 0.0))
+            y_max = float(box.get("ymax", 0.0))
+
+            x_min = max(0.0, min(x_min, width))
+            x_max = max(0.0, min(x_max, width))
+            y_min = max(0.0, min(y_min, height))
+            y_max = max(0.0, min(y_max, height))
+
+            if x_max <= x_min or y_max <= y_min:
+                continue
+
+            xyxy_list.append([x_min, y_min, x_max, y_max])
+            class_ids.append(coco_class_id)
+            confidences.append(1.0)
+
+        if not xyxy_list:
+            return sv.Detections.empty()
+
+        return sv.Detections(
+            xyxy=np.array(xyxy_list, dtype=np.float32),
+            class_id=np.array(class_ids, dtype=np.int32),
+            confidence=np.array(confidences, dtype=np.float32),
+        )

--- a/bv_core/gz_host_proxy.py
+++ b/bv_core/gz_host_proxy.py
@@ -1,0 +1,312 @@
+"""Host-side Gazebo proxy that forwards image and bbox topics over TCP."""
+
+import argparse
+import base64
+import json
+import queue
+import signal
+import socket
+import struct
+import threading
+import time
+from typing import Any
+
+import cv2
+import numpy as np
+from gz.msgs10.annotated_axis_aligned_2d_box_v_pb2 import AnnotatedAxisAligned2DBox_V
+from gz.msgs10.image_pb2 import Image as ImageMsg
+from gz.transport13 import Node as GzNode
+
+
+class ProxyServer:
+    """Bridge local Gazebo transport topics into a simple TCP stream."""
+
+    def __init__(self, host: str, port: int, image_topic: str, bbox_topic: str) -> None:
+        self._host = host
+        self._port = port
+        self._image_topic = image_topic
+        self._bbox_topic = bbox_topic
+        self._node = GzNode()
+        self._outgoing: "queue.Queue[bytes]" = queue.Queue(maxsize=200)
+        self._clients: list[socket.socket] = []
+        self._clients_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._server_sock: socket.socket | None = None
+
+        self._image_count = 0
+        self._bbox_count = 0
+        self._sent_count = 0
+        self._dropped_count = 0
+        self._stats_lock = threading.Lock()
+
+    def start(self) -> None:
+        image_ok = self._node.subscribe(ImageMsg, self._image_topic, self._handle_image)
+        bbox_ok = self._node.subscribe(
+            AnnotatedAxisAligned2DBox_V,
+            self._bbox_topic,
+            self._handle_bbox,
+        )
+        if not image_ok:
+            raise RuntimeError(f"Failed to subscribe to image topic {self._image_topic}")
+        if not bbox_ok:
+            raise RuntimeError(f"Failed to subscribe to bbox topic {self._bbox_topic}")
+
+        self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server_sock.bind((self._host, self._port))
+        self._server_sock.listen()
+        self._server_sock.settimeout(1.0)
+
+        threading.Thread(target=self._accept_loop, daemon=True).start()
+        threading.Thread(target=self._broadcast_loop, daemon=True).start()
+        threading.Thread(target=self._stats_loop, daemon=True).start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        try:
+            self._node.unsubscribe(self._image_topic)
+        except Exception:
+            pass
+        try:
+            self._node.unsubscribe(self._bbox_topic)
+        except Exception:
+            pass
+        if self._server_sock is not None:
+            try:
+                self._server_sock.close()
+            except OSError:
+                pass
+        with self._clients_lock:
+            for client in self._clients:
+                try:
+                    client.close()
+                except OSError:
+                    pass
+            self._clients.clear()
+
+    def wait(self) -> None:
+        while not self._stop.is_set():
+            time.sleep(0.25)
+
+    def _accept_loop(self) -> None:
+        assert self._server_sock is not None
+        while not self._stop.is_set():
+            try:
+                client, addr = self._server_sock.accept()
+                client.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                with self._clients_lock:
+                    self._clients.append(client)
+                print(f"[proxy] client connected from {addr[0]}:{addr[1]}", flush=True)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def _broadcast_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                packet = self._outgoing.get(timeout=0.5)
+            except queue.Empty:
+                continue
+
+            dead_clients: list[socket.socket] = []
+            with self._clients_lock:
+                for client in self._clients:
+                    try:
+                        client.sendall(packet)
+                    except OSError:
+                        dead_clients.append(client)
+                for client in dead_clients:
+                    try:
+                        client.close()
+                    except OSError:
+                        pass
+                    self._clients.remove(client)
+
+            with self._stats_lock:
+                self._sent_count += 1
+
+    def _stats_loop(self) -> None:
+        while not self._stop.is_set():
+            time.sleep(1.0)
+            with self._stats_lock, self._clients_lock:
+                print(
+                    "[proxy] "
+                    f"images={self._image_count} "
+                    f"bboxes={self._bbox_count} "
+                    f"sent={self._sent_count} "
+                    f"dropped={self._dropped_count} "
+                    f"clients={len(self._clients)}",
+                    flush=True,
+                )
+
+    def _enqueue(self, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        packet = struct.pack(">I", len(data)) + data
+        try:
+            self._outgoing.put_nowait(packet)
+        except queue.Full:
+            with self._stats_lock:
+                self._dropped_count += 1
+
+    def _handle_image(self, msg: ImageMsg) -> None:
+        if self._stop.is_set():
+            return
+        frame = self._image_to_numpy(msg)
+        if frame is None:
+            return
+
+        ok, encoded = cv2.imencode(".jpg", frame)
+        if not ok:
+            return
+
+        with self._stats_lock:
+            self._image_count += 1
+
+        self._enqueue(
+            {
+                "kind": "image",
+                "ts_ns": time.time_ns(),
+                "width": int(msg.width),
+                "height": int(msg.height),
+                "pixel_format": int(getattr(msg, "pixel_format_type", 0)),
+                "jpeg_b64": base64.b64encode(encoded.tobytes()).decode("ascii"),
+            }
+        )
+
+    def _handle_bbox(self, msg: AnnotatedAxisAligned2DBox_V) -> None:
+        if self._stop.is_set():
+            return
+
+        detections: list[dict[str, Any]] = []
+        for annotated_box in msg.annotated_box:
+            bbox = annotated_box.box
+            detections.append(
+                {
+                    "label": int(annotated_box.label),
+                    "xmin": float(bbox.min_corner.x),
+                    "ymin": float(bbox.min_corner.y),
+                    "xmax": float(bbox.max_corner.x),
+                    "ymax": float(bbox.max_corner.y),
+                }
+            )
+
+        with self._stats_lock:
+            self._bbox_count += 1
+
+        self._enqueue(
+            {
+                "kind": "bbox",
+                "ts_ns": time.time_ns(),
+                "detections": detections,
+            }
+        )
+
+    def _image_to_numpy(self, msg: ImageMsg) -> np.ndarray | None:
+        width, height = int(msg.width), int(msg.height)
+        if width <= 0 or height <= 0:
+            return None
+
+        row_bytes = int(msg.step) if getattr(msg, "step", 0) else 0
+        if row_bytes <= 0:
+            total_bytes = len(msg.data)
+            if total_bytes == 0 or total_bytes % height != 0:
+                return None
+            row_bytes = total_bytes // height
+
+        buffer = np.frombuffer(msg.data, dtype=np.uint8)
+        expected_size = height * row_bytes
+        if buffer.size < expected_size:
+            return None
+        if buffer.size > expected_size:
+            buffer = buffer[:expected_size]
+        if row_bytes < width:
+            return None
+
+        bytes_per_pixel = row_bytes // width if width else 0
+        if bytes_per_pixel == 0:
+            return None
+
+        if bytes_per_pixel in (1, 3, 4):
+            dtype = np.uint8
+        elif bytes_per_pixel in (2, 6, 8):
+            dtype = np.uint16
+        else:
+            return None
+
+        dtype_size = np.dtype(dtype).itemsize
+        if bytes_per_pixel % dtype_size != 0:
+            return None
+
+        channel_count = bytes_per_pixel // dtype_size
+        rows = buffer.reshape(height, row_bytes)
+        rows = rows[:, : width * bytes_per_pixel]
+        frame = rows.view(dtype)
+
+        if channel_count == 1:
+            frame = frame.reshape(height, width)
+        else:
+            frame = frame.reshape(height, width, channel_count)
+
+        pixel_format = getattr(msg, "pixel_format_type", None)
+
+        pf_rgb = getattr(ImageMsg, "PIXEL_FORMAT_RGB_INT8", 3)
+        pf_rgba = getattr(ImageMsg, "PIXEL_FORMAT_RGBA_INT8", 4)
+        pf_bgra = getattr(ImageMsg, "PIXEL_FORMAT_BGRA_INT8", 5)
+        pf_bgr = getattr(ImageMsg, "PIXEL_FORMAT_BGR_INT8", 8)
+
+        if frame.ndim == 3 and frame.dtype == np.uint8:
+            if pixel_format == pf_rgb and frame.shape[2] >= 3:
+                frame = frame[..., ::-1]
+            elif pixel_format == pf_rgba and frame.shape[2] >= 4:
+                frame = frame[..., [2, 1, 0, 3]]
+            elif pixel_format == pf_bgra:
+                pass
+            elif pixel_format == pf_bgr:
+                pass
+
+        if frame.ndim == 3 and frame.shape[2] == 4:
+            frame = frame[..., :3]
+
+        if frame.dtype != np.uint8:
+            frame = cv2.convertScaleAbs(
+                frame,
+                alpha=(255.0 / max(float(frame.max()), 1.0)),
+            )
+
+        return frame.copy()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=37031)
+    parser.add_argument("--image-topic", default="/camera/bounding_boxes_image")
+    parser.add_argument("--bbox-topic", default="/camera/bounding_boxes")
+    args = parser.parse_args()
+
+    server = ProxyServer(
+        host=args.host,
+        port=args.port,
+        image_topic=args.image_topic,
+        bbox_topic=args.bbox_topic,
+    )
+
+    def handle_signal(_signum: int, _frame: Any) -> None:
+        server.stop()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    server.start()
+    print(
+        f"[proxy] listening on {args.host}:{args.port} "
+        f"for {args.image_topic} and {args.bbox_topic}",
+        flush=True,
+    )
+    server.wait()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bv_core/pipelines/__init__.py
+++ b/bv_core/pipelines/__init__.py
@@ -16,11 +16,14 @@ def create_pipeline(pipeline_type: str, **config) -> Tuple[VisionPipeline, str]:
     Args:
         pipeline_type: Type of pipeline to create. Options:
             - "ros": ROS2 CompressedImage topic subscription
+            - "socket": TCP proxy subscription from the Mac host
             - "sim" / "gazebo": Gazebo transport image subscription
             - "real" / "camera": Physical camera or GStreamer pipeline
         **config: All configuration parameters. Factory picks what it needs.
             - gz_topic: Gazebo transport topic (used by sim/gazebo)
             - ros_topic: ROS image topic (used by ros)
+            - socket_host: Hostname for the TCP proxy (used by socket)
+            - socket_port: Port for the TCP proxy (used by socket)
             - node: ROS2 node instance (used by ros, camera)
             - gst_pipeline: GStreamer pipeline string (used by real/camera)
             - queue_size: Frame buffer size (default: 5)
@@ -48,6 +51,19 @@ def create_pipeline(pipeline_type: str, **config) -> Tuple[VisionPipeline, str]:
             topic=topic,
             queue_size=queue_size,
             qos_profile=config.get("qos_profile"),
+        )
+        return pipeline, topic
+
+    elif pipeline_type == "socket":
+        from .socket_cam_pipeline import SocketCamPipeline
+
+        host = config.get("socket_host", "127.0.0.1")
+        port = int(config.get("socket_port", 37031))
+        topic = f"socket://{host}:{port}/image"
+        pipeline = SocketCamPipeline(
+            host=host,
+            port=port,
+            queue_size=queue_size,
         )
         return pipeline, topic
 
@@ -80,5 +96,5 @@ def create_pipeline(pipeline_type: str, **config) -> Tuple[VisionPipeline, str]:
     else:
         raise ValueError(
             f"Unknown pipeline type: '{pipeline_type}'. "
-            f"Valid options: 'ros', 'sim', 'gazebo', 'real', 'camera'"
+            f"Valid options: 'ros', 'socket', 'sim', 'gazebo', 'real', 'camera'"
         )

--- a/bv_core/pipelines/socket_cam_pipeline.py
+++ b/bv_core/pipelines/socket_cam_pipeline.py
@@ -1,0 +1,66 @@
+"""Socket-fed vision pipeline that consumes proxied host camera frames."""
+
+import base64
+
+import cv2
+import numpy as np
+
+from ..socket_proxy_client import SocketProxySubscriber
+from .Vision_Pipeline import VisionPipeline
+
+
+class SocketCamPipeline(VisionPipeline):
+    """Receive JPEG-compressed frames from the host proxy over TCP."""
+
+    def __init__(self, host: str, port: int, *, queue_size: int = 1):
+        super().__init__(max_queue_size=queue_size)
+        self._host = host
+        self._port = port
+        self._running = False
+        self._subscriber = SocketProxySubscriber(
+            host=host,
+            port=port,
+            kind="image",
+            on_message=self._handle_image,
+            logger_name="socket_cam_pipeline",
+        )
+
+    def start(self):
+        if self._running:
+            return
+
+        self._subscriber.start()
+        self._running = True
+
+    def stop(self):
+        if not self._running:
+            return
+
+        self._subscriber.stop()
+        self._running = False
+        self._clear_queue()
+
+    def get_frame(self, timeout=None):
+        if not self._running:
+            raise RuntimeError("SocketCamPipeline must be started before getting frames")
+
+        return super().get_frame(timeout=timeout)
+
+    def _handle_image(self, message: dict) -> None:
+        if not self._running:
+            return
+
+        encoded = message.get("jpeg_b64")
+        if not encoded:
+            return
+
+        try:
+            jpg = base64.b64decode(encoded)
+        except (ValueError, TypeError):
+            return
+
+        frame = cv2.imdecode(np.frombuffer(jpg, dtype=np.uint8), cv2.IMREAD_COLOR)
+        if frame is None:
+            return
+
+        self._enqueue_frame(frame)

--- a/bv_core/socket_proxy_client.py
+++ b/bv_core/socket_proxy_client.py
@@ -1,0 +1,132 @@
+"""Shared client for reading framed JSON messages from the host proxy."""
+
+import json
+import socket
+import struct
+import threading
+import time
+from typing import Any, Callable
+
+import rclpy.logging
+
+
+class SocketProxySubscriber:
+    """Background TCP client that reconnects and forwards filtered messages."""
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        kind: str,
+        on_message: Callable[[dict[str, Any]], None],
+        logger_name: str,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._kind = kind
+        self._on_message = on_message
+        self._logger = rclpy.logging.get_logger(logger_name)
+
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._sock: socket.socket | None = None
+        self._sock_lock = threading.Lock()
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._close_socket()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def _run(self) -> None:
+        last_error_log = 0.0
+
+        while not self._stop.is_set():
+            sock: socket.socket | None = None
+
+            try:
+                sock = socket.create_connection((self._host, self._port), timeout=2.0)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                with self._sock_lock:
+                    self._sock = sock
+
+                self._logger.info(
+                    f"Connected to host proxy {self._host}:{self._port} for '{self._kind}'"
+                )
+
+                while not self._stop.is_set():
+                    message = self._recv_message(sock)
+                    if message.get("kind") != self._kind:
+                        continue
+
+                    try:
+                        self._on_message(message)
+                    except Exception as exc:
+                        self._logger.error(
+                            f"Failed to process '{self._kind}' message from proxy: {exc}"
+                        )
+
+            except OSError as exc:
+                now = time.monotonic()
+                if now - last_error_log > 5.0:
+                    self._logger.warn(
+                        f"Host proxy '{self._kind}' connection issue on "
+                        f"{self._host}:{self._port}: {exc}"
+                    )
+                    last_error_log = now
+            finally:
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+                with self._sock_lock:
+                    self._sock = None
+
+            if not self._stop.is_set():
+                time.sleep(1.0)
+
+    def _close_socket(self) -> None:
+        with self._sock_lock:
+            sock = self._sock
+            self._sock = None
+
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    def _recv_message(self, sock: socket.socket) -> dict[str, Any]:
+        header = self._recv_exact(sock, 4)
+        (size,) = struct.unpack(">I", header)
+        payload = self._recv_exact(sock, size)
+        return json.loads(payload.decode("utf-8"))
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, size: int) -> bytes:
+        chunks = []
+        remaining = size
+
+        while remaining > 0:
+            chunk = sock.recv(remaining)
+            if not chunk:
+                raise ConnectionError("socket closed while receiving framed proxy data")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+
+        return b"".join(chunks)

--- a/bv_core/stitching.py
+++ b/bv_core/stitching.py
@@ -17,7 +17,8 @@ import numpy as np
 import os
 # for stitching
 from mavros_msgs.msg import Waypoint, State as MavState, WaypointReached, CommandCode
-from .pipelines.gz_transport_pipeline import GzTransportPipeline
+from .pipelines import create_pipeline
+from .vision_config import load_vision_config
 
 from datetime import datetime
 
@@ -51,8 +52,11 @@ class ImageStitcherNode(Node):
         #counter for how many total pictures to take
         self.pic_counter = 0
 
-        # Match vision_node default camera topic (Gazebo gz transport bridge)
-        self.declare_parameter('image_topic', '/world/baylands/model/x500_gimbal_0/link/camera_link/sensor/camera/image')
+        vision_cfg = load_vision_config()
+        self.declare_parameter('pipeline_type', vision_cfg.get('pipeline_type', 'sim'))
+        self.declare_parameter('image_topic', vision_cfg.get('gz_topic', '/camera/bounding_boxes_image'))
+        self.declare_parameter('socket_host', vision_cfg.get('socket_host', '127.0.0.1'))
+        self.declare_parameter('socket_port', int(vision_cfg.get('socket_port', 37031)))
         # Directory where snapshots/stitched images are written
         self.declare_parameter('output_path', 'annotated_frames')
         self.declare_parameter('crop', True)
@@ -60,7 +64,10 @@ class ImageStitcherNode(Node):
         self.declare_parameter('stitch_interval_sec', 5.0)
 
         # Fetch parameters
+        pipeline_type = self.get_parameter('pipeline_type').get_parameter_value().string_value
         image_topic = self.get_parameter('image_topic').get_parameter_value().string_value
+        socket_host = self.get_parameter('socket_host').get_parameter_value().string_value
+        socket_port = self.get_parameter('socket_port').get_parameter_value().integer_value
         self.output_path = self.get_parameter('output_path').get_parameter_value().string_value
         self.crop = self.get_parameter('crop').get_parameter_value().bool_value
         self.preprocessing = self.get_parameter('preprocessing').get_parameter_value().bool_value
@@ -69,16 +76,21 @@ class ImageStitcherNode(Node):
         # Ensure output directory exists
         os.makedirs(self.output_path, exist_ok=True)
 
-        # Gazebo transport pipeline (same feed as vision_node)
-        self.pipeline_topic = image_topic
-        self.pipeline = GzTransportPipeline(topic=self.pipeline_topic, queue_size=5)
+        self.pipeline, self.pipeline_topic = create_pipeline(
+            pipeline_type,
+            gz_topic=image_topic,
+            socket_host=socket_host,
+            socket_port=socket_port,
+            node=self,
+            queue_size=5,
+        )
         self.pipeline_running = False
         try:
             self.pipeline.start()
             self.pipeline_running = True
-            self.get_logger().info(f"Gazebo image pipeline started on {self.pipeline_topic}")
+            self.get_logger().info(f"Image pipeline started on {self.pipeline_topic}")
         except RuntimeError as exc:
-            self.get_logger().error(f"Failed to start Gazebo pipeline: {exc}")
+            self.get_logger().error(f"Failed to start image pipeline: {exc}")
 
         # Subscribe to the state the drone is in
         self.mission_state_sub = self.create_subscription(
@@ -100,7 +112,9 @@ class ImageStitcherNode(Node):
 
         # Helpers & buffer
         self.received_images = []
-        self.get_logger().info(f"Subscribed to {image_topic}`; stitch every {self.stitch_interval_sec}s")
+        self.get_logger().info(
+            f"Subscribed to {self.pipeline_topic}; stitch every {self.stitch_interval_sec}s"
+        )
 
     def state_callback(self, msg: String):
         try:

--- a/bv_core/vision_config.py
+++ b/bv_core/vision_config.py
@@ -1,0 +1,18 @@
+"""Helpers for loading shared vision configuration."""
+
+import os
+
+import yaml
+from ament_index_python.packages import get_package_share_directory
+
+
+def load_vision_config() -> dict:
+    """Load ``vision_params.yaml`` from the installed package share directory."""
+    vision_yaml = os.path.join(
+        get_package_share_directory("bv_core"),
+        "config",
+        "vision_params.yaml",
+    )
+
+    with open(vision_yaml, "r") as handle:
+        return yaml.safe_load(handle) or {}

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -40,6 +40,7 @@ from collections import deque
 from .detectors import create_detector
 from .pipelines import create_pipeline
 from .localizer import Localizer
+from .vision_config import load_vision_config
 
 # ROS2 utilities
 from ament_index_python.packages import get_package_share_directory
@@ -84,14 +85,7 @@ class VisionNode(Node):
 
     def _load_config(self):
         """Load configuration from vision_params.yaml."""
-        vision_yaml = os.path.join(
-            get_package_share_directory('bv_core'),
-            'config',
-            'vision_params.yaml'
-        )
-
-        with open(vision_yaml, 'r') as f:
-            cfg = yaml.safe_load(f)
+        cfg = load_vision_config()
 
         # Detection settings
         self.batch_size = cfg.get('batch_size', 4)
@@ -118,6 +112,8 @@ class VisionNode(Node):
         self.camera_fps = cfg.get('camera_fps', 30.0)
         self.record_video = cfg.get('record_video', False)
         self.ros_image_topic = cfg.get('ros_image_topic', '/image_compressed')
+        self.socket_host = cfg.get('socket_host', '127.0.0.1')
+        self.socket_port = int(cfg.get('socket_port', 37031))
 
     def _init_state(self):
         """Initialize state tracking variables."""
@@ -138,6 +134,8 @@ class VisionNode(Node):
             self.pipeline_type,
             gz_topic=self.gz_topic,
             ros_topic=self.ros_image_topic,
+            socket_host=self.socket_host,
+            socket_port=self.socket_port,
             node=self,
             gst_pipeline=self.gst_pipeline_str,
             record=self.record_video,
@@ -230,6 +228,8 @@ class VisionNode(Node):
             batch_size=self.batch_size,
             resolution=self.resolution,
             gazebo_bbox_topic=self.gazebo_bbox_topic,
+            socket_host=self.socket_host,
+            socket_port=self.socket_port,
         )
         self.detector.start()
 

--- a/config/vision_params.yaml
+++ b/config/vision_params.yaml
@@ -12,15 +12,19 @@ estimated_camera_latency: 0.5  # Seconds to pause after stopping before capturin
 num_scan_wp: 3
 
 # Detector configuration
-detector_type: "gazebo_bbox"  # Options: "ml" (RF-DETR), "gazebo_bbox" (Gazebo bounding box camera)
+detector_type: "gazebo_bbox"  # Options: "ml" (RF-DETR), "gazebo_bbox" (direct Gazebo), "socket_bbox" (host proxy)
 gazebo_bbox_topic: "/camera/bounding_boxes"  # Topic for Gazebo bbox camera (only used when detector_type is "gazebo_bbox")
 
 # ============================================================
 # PIPELINE CONFIGURATION
 # ============================================================
 
-# Pipeline type: 'sim', 'real', or 'ros'
+# Pipeline type: 'socket', 'sim', 'real', or 'ros'
 pipeline_type: 'sim'
+
+# Host proxy settings (used when pipeline_type: 'socket' or detector_type: 'socket_bbox')
+socket_host: '127.0.0.1'
+socket_port: 37031
 
 # Gazebo simulation settings (used when pipeline_type: 'sim')
 # Change this if drone or world changes

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
             'filtering_node = bv_core.filtering_node:main',
             'stitching_node = bv_core.stitching:main',
             'bv_viz_node = bv_core.bv_viz_node:main',
+            'gz_host_proxy = bv_core.gz_host_proxy:main',
             'test_servo = bv_core.test_servo:main',
             'camera_pipeline_test_node = bv_core.camera_pipeline_test_node:main',
             'test_obj_loc = bv_core.test_obj_loc:main',


### PR DESCRIPTION
## What changed

- Added a socket-fed image pipeline and bbox detector so Linux ROS nodes can consume Gazebo image and bbox data through a plain TCP proxy instead of direct Gazebo Transport.
- Added a host-side `gz_host_proxy` entry point and module that subscribe to local Gazebo topics and forward `/camera/bounding_boxes_image` and `/camera/bounding_boxes` over a framed TCP stream.
- Added a shared `vision_config` loader so `vision_node` and `stitching_node` follow the same `vision_params.yaml` backend selection.
- Kept the new socket implementation optional. The shared defaults in `config/vision_params.yaml` remain on the original direct Gazebo path:
  - `pipeline_type: sim`
  - `detector_type: gazebo_bbox`
- Cleaned up detector imports so backend-specific dependencies are imported lazily in the detector factory, matching the existing pipeline-factory pattern more closely.

## Why these changes

On Apple Silicon macOS with PX4 and Gazebo running on the host and ROS nodes running in Linux under OrbStack/Docker, direct Gazebo Transport did not deliver payloads into Linux. Discovery could work, but the advertised payload endpoints remained loopback (`127.0.0.1`), so remote Linux consumers could not receive image or bbox data.

The socket proxy path avoids that failure mode:

- PX4 + Gazebo stay on the Mac host.
- A lightweight host proxy subscribes to Gazebo locally, where payload delivery works.
- Linux ROS nodes consume the proxied image and bbox stream over a normal TCP socket.

This keeps the original PC/Linux direct-Gazebo path intact while adding a workable Mac-host option.

## How to run `mission.launch.py` after these changes

### Original PC/Linux direct Gazebo path

No behavior change is required. The defaults remain:

```yaml
pipeline_type: "sim"
detector_type: "gazebo_bbox"
```

Build and run as before.

### Mac host PX4/Gazebo + Linux container path

1. In `config/vision_params.yaml`, switch to:

```yaml
pipeline_type: "socket"
detector_type: "socket_bbox"
socket_host: "127.0.0.1"
socket_port: 37031
```

2. On the Mac host, run PX4 + Gazebo.
3. On the Mac host, run the proxy from the repo checkout in the same Gazebo/Python environment:

```bash
export GZ_IP=127.0.0.1
cd src/bv_core
python3 -m bv_core.gz_host_proxy
```

This host-side proxy path does not require native ROS on macOS. It does require the host Python environment to have the Gazebo Python bindings and any needed Python dependencies available.

4. In Linux/OrbStack, rebuild and source the workspace:

```bash
source /opt/ros/humble/setup.bash
cd /bv_ws
colcon build --packages-select bv_core --symlink-install
source /bv_ws/install/setup.bash
```

5. Start MAVROS, wait for PX4 readiness / connection, then launch:

```bash
ros2 launch bv_core mission.launch.py
```

`stitching_node` now follows the same shared vision config, so backend switches only need to happen in `vision_params.yaml`.

## Validation

### Build / static validation

- `python3 -m py_compile` on the new socket / proxy / config modules
- `colcon build --packages-select bv_core --symlink-install` in the OrbStack Linux container

### Runtime validation

- Verified the Mac host proxy subscribed locally to `/camera/bounding_boxes_image` and `/camera/bounding_boxes` and streamed frames + bbox payloads over TCP.
- Verified Linux OrbStack clients decoded live proxied `1280x720` frames.
- Verified `vision_node` and `stitching_node` connected to the socket proxy in Linux.
- Ran the full live sequence:
  1. Start PX4 + Gazebo on the Mac host
  2. Wait for PX4 `Ready for takeoff!`
  3. Start MAVROS in Linux
  4. Wait 10 seconds
  5. Launch `ros2 launch bv_core mission.launch.py`
- Observed mission progress through `TAKEOFF`, `LAP`, `SCAN`, `LOCALIZE`, and `DELIVER`.
- Observed live detections and mission reactions in the container, including confirmed detections for `car` and `sports ball`, successful localization requests, and waypoint pushes for delivery.

## Notes

- This PR intentionally leaves the socket path in the repo but inactive by default so Linux/PC users keep the original workflow.
- The broader codebase still has some preexisting non-lazy imports for COCO class-name lookup outside the backend factories; that is separate from this PR’s runtime fix.
