### PR TITLE
Improve mission logging and operator-facing log readability

### DIFF
--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -24,6 +24,7 @@ import time
 from collections import deque
 from rclpy.time import Time
 import math
+from .mission_logger import MissionLogger
 
 class FilteringNode(Node):
     def __init__(self):
@@ -121,6 +122,8 @@ class FilteringNode(Node):
 
         self.last_rel_alt = None
         self._last_window_print_time = 0.0
+        self.log = MissionLogger('filtering')
+        self.proximity_threshold_deg = 0.00005  # ~5.5m, used in _check_3frame_confirmation
 
     def handle_gps(self, msg: NavSatFix):
         self.gps_buffer.append(msg)
@@ -188,7 +191,7 @@ class FilteringNode(Node):
         filtered_detections = [
             (lat, lon, cls)
             for lat, lon, cls in detections_global
-            if not self._is_near_deployed_location(lat, lon)
+            if not self._is_near_deployed_location(lat, lon, cls)
         ]
         ignored_count = len(detections_global) - len(filtered_detections)
         # if ignored_count > 0:
@@ -216,6 +219,28 @@ class FilteringNode(Node):
             for i, frame_dets in enumerate(self.frame_history):
                 class_names = set(COCO_CLASS_NAMES[int(cls)] for _, _, cls in frame_dets)
                 self.get_logger().info(f"Frame {i}: {class_names}")
+
+        # Log frame window with distances for tuning
+        window_data = {}
+        for cls_id in set(int(c) for frame in self.frame_history for _, _, c in frame):
+            cls_name = COCO_CLASS_NAMES[cls_id]
+            positions = []
+            for frame_dets in self.frame_history:
+                for lat, lon, c in frame_dets:
+                    if int(c) == cls_id:
+                        positions.append((lat, lon))
+                        break
+            dists = []
+            for j in range(len(positions) - 1):
+                d_deg = math.sqrt((positions[j+1][0] - positions[j][0])**2 +
+                                  (positions[j+1][1] - positions[j][1])**2)
+                d_m = d_deg * 111320.0
+                dists.append(d_m)
+            window_data[cls_name] = {
+                'dists': dists,
+                'thresh': self.proximity_threshold_deg * 111320.0,
+            }
+        self.log.frame_window(len(self.frame_history), 3, window_data)
 
         # Check for consistent detection across 3 frames
         confirmed_class = self._check_3frame_confirmation()
@@ -257,7 +282,7 @@ class FilteringNode(Node):
             return None
         
         # For each common class, check spatial proximity
-        PROXIMITY_THRESHOLD_DEG =  0.00005  #5.5 meters maybe can tighten
+        PROXIMITY_THRESHOLD_DEG = self.proximity_threshold_deg
         
         for cls in common_classes:
             # Get positions for this class in each frame
@@ -267,34 +292,53 @@ class FilteringNode(Node):
                     if int(c) == cls:
                         positions.append((lat, lon))
                         break  # Take first detection of this class per frame
-            
+
             if len(positions) < 3:
                 continue
-            
+
             # Check if CONSECUTIVE positions are within proximity
-            # Only compare consecutive frames (0->1, 1->2) not all pairs
-            # This avoids cumulative drift from failing the check
             all_close = True
+            dists_m = []
             for i in range(len(positions) - 1):
                 lat1, lon1 = positions[i]
                 lat2, lon2 = positions[i + 1]
                 dist = math.sqrt((lat2 - lat1)**2 + (lon2 - lon1)**2)
+                dists_m.append(dist * 111320.0)
                 if dist > PROXIMITY_THRESHOLD_DEG:
                     all_close = False
                     break
-            
+
+            cls_name = COCO_CLASS_NAMES[int(cls)]
+            thresh_m = PROXIMITY_THRESHOLD_DEG * 111320.0
             if all_close:
+                self.log.event('CONFIRMED',
+                    f"class={cls_name}({cls}), "
+                    f"dists=[{','.join(f'{d:.1f}m' for d in dists_m)}], "
+                    f"thresh={thresh_m:.1f}m")
                 return cls
-        
+            else:
+                self.log.event('REJECTED',
+                    f"class={cls_name}({cls}), "
+                    f"dists=[{','.join(f'{d:.1f}m' for d in dists_m)}], "
+                    f"thresh={thresh_m:.1f}m, reason=proximity_fail")
+
         return None
 
     def deployed_location_callback(self, msg: ObjectLocations):
         self.deployed_locations.append((msg.latitude, msg.longitude, msg.class_id))
 
-    def _is_near_deployed_location(self, lat: float, lon: float) -> bool:
+    def _is_near_deployed_location(self, lat: float, lon: float, cls_id: int = -1) -> bool:
         for deployed_lat, deployed_lon, _ in self.deployed_locations:
             distance = math.sqrt((lat - deployed_lat) ** 2 + (lon - deployed_lon) ** 2)
             if distance <= self.deployed_ignore_radius_deg:
+                dist_m = distance * 111320.0
+                thresh_m = self.deployed_ignore_radius_deg * 111320.0
+                cls_name = COCO_CLASS_NAMES[int(cls_id)] if cls_id >= 0 and cls_id < len(COCO_CLASS_NAMES) else 'unknown'
+                self.log.event('DEPLOYED_IGNORE',
+                    f"class={cls_name}({cls_id}), "
+                    f"det_pos=({lat:.6f},{lon:.6f}), "
+                    f"deployed_pos=({deployed_lat:.6f},{deployed_lon:.6f}), "
+                    f"dist={dist_m:.1f}m, thresh={thresh_m:.1f}m")
                 return True
         return False
 

--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -92,6 +92,7 @@ class FilteringNode(Node):
         # === 3-frame confirmation tracking ===
         self.frame_history = []  # list of recent detection sets [(lat, lon, class_id), ...]
         self.already_confirmed_classes = set()  # avoid re-triggering same object
+        self._last_frame_window_summary = None
         
         # === publisher for confirmed detections ===
         # Use same reliable QoS pattern for /global_obj_dets
@@ -121,7 +122,6 @@ class FilteringNode(Node):
         )
 
         self.last_rel_alt = None
-        self._last_window_print_time = 0.0
         self.log = MissionLogger('filtering')
         self.proximity_threshold_deg = 0.00005  # ~5.5m, used in _check_3frame_confirmation
 
@@ -212,13 +212,16 @@ class FilteringNode(Node):
         if len(self.frame_history) > 3:
             self.frame_history.pop(0)
 
-        # Rate-limited print of class names in frame window (1/sec)
-        now = time.time()
-        if now - self._last_window_print_time >= 1.0:
-            self._last_window_print_time = now
-            for i, frame_dets in enumerate(self.frame_history):
-                class_names = set(COCO_CLASS_NAMES[int(cls)] for _, _, cls in frame_dets)
-                self.get_logger().info(f"Frame {i}: {class_names}")
+        # Print the current 3-frame detection window in plain English.
+        frame_summaries = []
+        for i, frame_dets in enumerate(self.frame_history):
+            class_names = sorted(set(COCO_CLASS_NAMES[int(cls)] for _, _, cls in frame_dets))
+            detected_text = ', '.join(class_names) if class_names else 'no objects'
+            frame_summaries.append(f"frame {i + 1}: {detected_text}")
+        frame_window_summary = "Recent detection window: " + " | ".join(frame_summaries)
+        if frame_window_summary != self._last_frame_window_summary:
+            self.get_logger().info(frame_window_summary)
+            self._last_frame_window_summary = frame_window_summary
 
         # Log frame window with distances for tuning
         window_data = {}
@@ -349,6 +352,7 @@ class FilteringNode(Node):
             # detections from deliver/deploy phases carrying into scan
             if msg.data in ('localize', 'deliver', 'deploy', 'scan'):
                 self.frame_history.clear()
+                self._last_frame_window_summary = None
 
             if msg.data == 'scan':
                 self.already_confirmed_classes.clear()

--- a/bv_core/localizer.py
+++ b/bv_core/localizer.py
@@ -37,6 +37,7 @@ class Localizer:
         self.eps = eps
         self.min_samples = min_samples
         self.geod = Geodesic.WGS84
+        self._warned_no_detections = False
 
         filtering_yaml = os.path.join(
             get_package_share_directory('bv_core'),
@@ -69,8 +70,11 @@ class Localizer:
         """
 
         if not pixel_centers:
-            rclpy.logging.get_logger("localizer").warn("No pixel centers provided, returning empty list")
+            if not self._warned_no_detections:
+                rclpy.logging.get_logger("localizer").warn("No objects detected in frame")
+                self._warned_no_detections = True
             return []
+        self._warned_no_detections = False
 
         # 1) Undistort to normalized image plane
         pts = np.array([(u, v) for u, v, _ in pixel_centers], dtype=np.float32)

--- a/bv_core/mission.py
+++ b/bv_core/mission.py
@@ -40,6 +40,9 @@ from ament_index_python.packages import get_package_share_directory
 
 from bv_msgs.srv import LocalizeObject
 from bv_msgs.msg import ObjectLocations
+from .mission_logger import MissionLogger
+from rfdetr.util.coco_classes import COCO_CLASSES
+COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
 
 # Mission configuration
 NUM_OBJECTS_TO_FIND = 4          # Total number of objects to detect and deliver to
@@ -76,7 +79,8 @@ class MissionRunner(Node):
         
         # Load configuration from YAML
         self.load_config_from_yaml()
-        
+        self.log = MissionLogger('mission')
+
         # Initialize state variables
         self.init_state_variables()
         
@@ -94,7 +98,15 @@ class MissionRunner(Node):
         self.get_logger().info("MISSION STARTING")
         self.get_logger().info(f"Objects to find: {self.num_objects_to_find}")
         self.get_logger().info("=" * 50)
-        
+        self.log.event('STARTUP',
+            f"num_objects={self.num_objects_to_find}, "
+            f"scan_wps={len(self.scan_waypoints)}, "
+            f"lap_wps={len(self.lap_waypoints)}, "
+            f"scan_vel={self.scan_velocity}m/s, "
+            f"deliver_vel={self.deliver_velocity}m/s, "
+            f"scan_tol={self.scan_tolerance}m, "
+            f"deliver_tol={self.deliver_tolerance}m")
+
         self.enter_takeoff_state()
         
         # Start main timer loop
@@ -331,6 +343,8 @@ class MissionRunner(Node):
         elif self.current_state == STATE_SCAN:
             # Scan waypoints finished - proceed to RTL
             self.get_logger().info("Scan complete")
+            self.log.event('SCAN_COMPLETE',
+                f"objects_delivered={self.objects_delivered_count}/{self.num_objects_to_find}, action=rtl")
             self.enter_rtl_state()
             
         elif self.current_state == STATE_LOCALIZE:
@@ -372,7 +386,8 @@ class MissionRunner(Node):
         self.get_logger().info("-" * 40)
         self.get_logger().info("ENTERING STATE: TAKEOFF")
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', 'takeoff')
+
         # Use first lap point as takeoff destination
         if not self.lap_waypoints:
             self.get_logger().error("No lap waypoints defined!")
@@ -401,7 +416,8 @@ class MissionRunner(Node):
         self.get_logger().info("-" * 40)
         self.get_logger().info("ENTERING STATE: LAP")
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', 'takeoff -> lap')
+
         self.active_waypoint_list = self.build_waypoint_list(
             self.lap_waypoints,
             self.lap_tolerance,
@@ -431,7 +447,8 @@ class MissionRunner(Node):
             f"Resuming from waypoint index: {self.scan_waypoint_index_on_detection}"
         )
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', f"-> scan (resume from wp {self.scan_waypoint_index_on_detection})")
+
         # Get remaining scan waypoints from where we left off
         remaining_scan_points = self.scan_waypoints[self.scan_waypoint_index_on_detection:]
 
@@ -473,7 +490,8 @@ class MissionRunner(Node):
         self.get_logger().info("-" * 40)
         self.get_logger().info("ENTERING STATE: LOCALIZE")
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', 'scan -> localize')
+
         # Publish state so vision node knows to keep pipeline running
         self.publish_mission_state()
         
@@ -501,7 +519,8 @@ class MissionRunner(Node):
         self.get_logger().info("-" * 40)
         self.get_logger().info("ENTERING STATE: DELIVER")
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', 'localize -> deliver')
+
         if self.current_target_coords is None:
             self.get_logger().error("No target coordinates available!")
             self.enter_rtl_state()
@@ -509,7 +528,10 @@ class MissionRunner(Node):
         
         lat, lon, alt = self.current_target_coords
         self.get_logger().info(f"Flying to target: lat={lat:.6f}, lon={lon:.6f}")
-        
+        cls_name = COCO_CLASS_NAMES[self.current_target_class_id] if self.current_target_class_id is not None and self.current_target_class_id < len(COCO_CLASS_NAMES) else 'unknown'
+        self.log.event('DELIVER_TARGET',
+            f"lat={lat:.6f}, lon={lon:.6f}, class={cls_name}({self.current_target_class_id})")
+
         self.active_waypoint_list = self.build_waypoint_list(
             [self.current_target_coords],
             self.deliver_tolerance
@@ -532,7 +554,8 @@ class MissionRunner(Node):
             f"Deploying payload {self.objects_delivered_count + 1}/{self.num_objects_to_find}"
         )
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', 'deliver -> deploy')
+
         # Initialize servo state machine
         self.deploy_servo_state = 0
         self.deploy_state_start_time = time.monotonic()
@@ -551,7 +574,8 @@ class MissionRunner(Node):
         self.get_logger().info("-" * 40)
         self.get_logger().info("ENTERING STATE: RTL")
         self.get_logger().info("-" * 40)
-        
+        self.log.event('STATE_CHANGE', '-> rtl')
+
         self.set_flight_mode("AUTO.RTL")
 
     # Mavros utilities
@@ -719,16 +743,19 @@ class MissionRunner(Node):
             # Extend
             self.get_logger().info(f"[DEPLOY] CH{servo_channel} <- {initial_pwm} (extend)")
             self.set_servo_pwm(servo_channel, initial_pwm)
-            
+            self.log.event('DEPLOY_SERVO', f"step=extend, ch={servo_channel}, pwm={initial_pwm}")
+
         elif self.deploy_servo_state == 1:
             # Retract
             self.get_logger().info(f"[DEPLOY] CH{servo_channel} <- {second_pwm} (retract)")
             self.set_servo_pwm(servo_channel, second_pwm)
-            
+            self.log.event('DEPLOY_SERVO', f"step=retract, ch={servo_channel}, pwm={second_pwm}")
+
         elif self.deploy_servo_state == 2:
             # Return to idle
             self.get_logger().info(f"[DEPLOY] CH{servo_channel} <- {default_pwm} (idle)")
             self.set_servo_pwm(servo_channel, default_pwm)
+            self.log.event('DEPLOY_SERVO', f"step=idle, ch={servo_channel}, pwm={default_pwm}")
 
     def on_deploy_complete(self):
         """Called when the servo deploy sequence finishes."""
@@ -739,6 +766,19 @@ class MissionRunner(Node):
             deployed_msg.longitude = float(lon)
             deployed_msg.class_id = int(self.current_target_class_id) if self.current_target_class_id is not None else -1
             self.deployed_object_pub.publish(deployed_msg)
+            cls_name = COCO_CLASS_NAMES[int(deployed_msg.class_id)] if deployed_msg.class_id >= 0 and deployed_msg.class_id < len(COCO_CLASS_NAMES) else 'unknown'
+            actual_pos = (self.current_lat, self.current_lon) if self.current_lat is not None else (lat, lon)
+            self.log.deploy_complete(
+                class_id=deployed_msg.class_id,
+                class_name=cls_name,
+                target_pos=(lat, lon),
+                actual_pos=actual_pos,
+                delivered_count=self.objects_delivered_count + 1,
+                total=self.num_objects_to_find
+            )
+            self.log.event('DEPLOYED_LOCATION',
+                f"lat={lat:.6f}, lon={lon:.6f}, class={cls_name}({deployed_msg.class_id}), "
+                f"ignore_radius=0.0001deg")
             self.get_logger().info(
                 f"Published deployed object location: lat={lat:.6f}, lon={lon:.6f}, "
                 f"class_id={deployed_msg.class_id}"
@@ -772,6 +812,8 @@ class MissionRunner(Node):
             self.get_logger().info(
                 f"Resuming scan from waypoint {self.scan_waypoint_index_on_detection}"
             )
+            self.log.event('SCAN_RESUME',
+                f"from_wp={self.scan_waypoint_index_on_detection}/{len(self.scan_waypoints)}")
             self.enter_scan_state()
 
     # Callbacks - service responses
@@ -870,6 +912,9 @@ class MissionRunner(Node):
                 self.get_logger().warn(
                     "Localization failed 5 times - abandoning this object and resuming scan"
                 )
+                cls_name = COCO_CLASS_NAMES[self.confirmed_detection_class_id] if self.confirmed_detection_class_id >= 0 and self.confirmed_detection_class_id < len(COCO_CLASS_NAMES) else 'unknown'
+                self.log.event('LOCALIZE_ABANDONED',
+                    f"class={cls_name}({self.confirmed_detection_class_id}), attempts=5, resuming_scan")
                 # Stop any pending retry timer
                 if self._localize_retry_timer is not None:
                     self._localize_retry_timer.cancel()
@@ -922,6 +967,8 @@ class MissionRunner(Node):
             self.home_lat = msg.latitude
             self.home_lon = msg.longitude
             self.home_alt = msg.altitude
+            self.log.event('HOME_SET',
+                f"lat={self.home_lat:.6f}, lon={self.home_lon:.6f}, alt={self.home_alt:.2f}")
 
     def on_waypoint_reached(self, msg):
         """Callback when a waypoint is reached."""
@@ -952,7 +999,10 @@ class MissionRunner(Node):
         self.get_logger().info(
             f"Reached waypoint {waypoint_index} (state={self.current_state})"
         )
-        
+        is_final = (waypoint_index == self.expected_final_waypoint_index)
+        self.log.event('WP_REACHED',
+            f"wp={waypoint_index}, state={self.current_state}, final={is_final}")
+
         # Check if this was the final waypoint
         if waypoint_index == self.expected_final_waypoint_index:
             self.handle_state_completion()
@@ -990,7 +1040,10 @@ class MissionRunner(Node):
         
         # Store which class was confirmed so we can tell the localizer
         self.confirmed_detection_class_id = int(msg.data)
-        
+        cls_name = COCO_CLASS_NAMES[int(msg.data)] if int(msg.data) < len(COCO_CLASS_NAMES) else 'unknown'
+        self.log.event('OBJECT_DETECTED',
+            f"class={cls_name}({msg.data}), delivered_so_far={self.objects_delivered_count}/{self.num_objects_to_find}")
+
         # Mark as transitioning to prevent duplicate triggers
         self.is_transitioning = True
         
@@ -1001,6 +1054,9 @@ class MissionRunner(Node):
         if self.current_lat is not None and self.current_lon is not None:
             scan_alt = self.scan_waypoints[0][2]  # Use scan altitude
             self.loiter_resume_coords = (self.current_lat, self.current_lon, scan_alt)
+            self.log.event('LOITER_SAVED',
+                f"lat={self.current_lat:.6f}, lon={self.current_lon:.6f}, "
+                f"scan_wp_progress={self.last_reached_scan_waypoint}/{len(self.scan_waypoints)}")
             self.get_logger().info(
                 f"Saved loiter position: lat={self.current_lat:.6f}, lon={self.current_lon:.6f}"
             )
@@ -1059,6 +1115,7 @@ def main(args=None):
     except KeyboardInterrupt:
         node.get_logger().info("Mission interrupted by user")
     finally:
+        node.log.close()
         node.destroy_node()
         rclpy.shutdown()
 

--- a/bv_core/mission.py
+++ b/bv_core/mission.py
@@ -41,8 +41,6 @@ from ament_index_python.packages import get_package_share_directory
 from bv_msgs.srv import LocalizeObject
 from bv_msgs.msg import ObjectLocations
 from .mission_logger import MissionLogger
-from rfdetr.util.coco_classes import COCO_CLASSES
-COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
 
 # Mission configuration
 NUM_OBJECTS_TO_FIND = 4          # Total number of objects to detect and deliver to
@@ -531,7 +529,7 @@ class MissionRunner(Node):
             return
         
         lat, lon, alt = self.current_target_coords
-        cls_name = COCO_CLASS_NAMES[self.current_target_class_id] if self.current_target_class_id is not None and self.current_target_class_id < len(COCO_CLASS_NAMES) else 'unknown'
+        cls_name = CLASS_NAMES[self.current_target_class_id] if self.current_target_class_id is not None and 0 <= self.current_target_class_id < len(CLASS_NAMES) else 'unknown'
         self.get_logger().info(f"Flying to {cls_name}: lat={lat:.6f}, lon={lon:.6f}")
         self.log.event('DELIVER_TARGET',
             f"lat={lat:.6f}, lon={lon:.6f}, class={cls_name}({self.current_target_class_id})")
@@ -722,14 +720,13 @@ class MissionRunner(Node):
         request = LocalizeObject.Request()
         request.target_class_id = self.confirmed_detection_class_id
         target_name = (
-            COCO_CLASS_NAMES[request.target_class_id]
-            if 0 <= request.target_class_id < len(COCO_CLASS_NAMES)
+            CLASS_NAMES[request.target_class_id]
+            if 0 <= request.target_class_id < len(CLASS_NAMES)
             else 'any object'
         )
         
         self.get_logger().info(
-            f"Requesting localization from vision node for {target_name} "
-            f"(class_id={request.target_class_id})..."
+            f"Requesting localization from vision node for {target_name}..."
         )
         
         future = self.localize_object_client.call_async(request)
@@ -776,7 +773,7 @@ class MissionRunner(Node):
             deployed_msg.longitude = float(lon)
             deployed_msg.class_id = int(self.current_target_class_id) if self.current_target_class_id is not None else -1
             self.deployed_object_pub.publish(deployed_msg)
-            cls_name = COCO_CLASS_NAMES[int(deployed_msg.class_id)] if deployed_msg.class_id >= 0 and deployed_msg.class_id < len(COCO_CLASS_NAMES) else 'unknown'
+            cls_name = CLASS_NAMES[int(deployed_msg.class_id)] if 0 <= deployed_msg.class_id < len(CLASS_NAMES) else 'unknown'
             actual_pos = (self.current_lat, self.current_lon) if self.current_lat is not None else (lat, lon)
             self.log.deploy_complete(
                 class_id=deployed_msg.class_id,
@@ -922,7 +919,7 @@ class MissionRunner(Node):
                 self.get_logger().warn(
                     "Localization failed 5 times - abandoning this object and resuming scan"
                 )
-                cls_name = COCO_CLASS_NAMES[self.confirmed_detection_class_id] if self.confirmed_detection_class_id >= 0 and self.confirmed_detection_class_id < len(COCO_CLASS_NAMES) else 'unknown'
+                cls_name = CLASS_NAMES[self.confirmed_detection_class_id] if 0 <= self.confirmed_detection_class_id < len(CLASS_NAMES) else 'unknown'
                 self.log.event('LOCALIZE_ABANDONED',
                     f"class={cls_name}({self.confirmed_detection_class_id}), attempts=5, resuming_scan")
                 # Stop any pending retry timer
@@ -960,14 +957,14 @@ class MissionRunner(Node):
         self.current_target_coords = (response.latitude, response.longitude, response.altitude)
         self.current_target_class_id = int(response.class_id)
         cls_name = (
-            COCO_CLASS_NAMES[self.current_target_class_id]
-            if 0 <= self.current_target_class_id < len(COCO_CLASS_NAMES)
+            CLASS_NAMES[self.current_target_class_id]
+            if 0 <= self.current_target_class_id < len(CLASS_NAMES)
             else 'unknown'
         )
         
         self.get_logger().info(
             f"Localized {cls_name} at: lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
-            f"alt={response.altitude:.2f}m (class_id={response.class_id})"
+            f"alt={response.altitude:.2f}m"
         )
         
         # Proceed to delivery
@@ -1062,7 +1059,7 @@ class MissionRunner(Node):
         
         # Store which class was confirmed so we can tell the localizer
         self.confirmed_detection_class_id = int(msg.data)
-        cls_name = COCO_CLASS_NAMES[int(msg.data)] if int(msg.data) < len(COCO_CLASS_NAMES) else 'unknown'
+        cls_name = CLASS_NAMES[int(msg.data)] if 0 <= int(msg.data) < len(CLASS_NAMES) else 'unknown'
         self.log.event('OBJECT_DETECTED',
             f"class={cls_name}({msg.data}), delivered_so_far={self.objects_delivered_count}/{self.num_objects_to_find}")
 

--- a/bv_core/mission.py
+++ b/bv_core/mission.py
@@ -321,8 +321,11 @@ class MissionRunner(Node):
         ]
         
         for client, name in services:
+            has_logged_wait = False
             while not client.wait_for_service(timeout_sec=1.0):
-                self.get_logger().info(f"Waiting for service: {name}")
+                if not has_logged_wait:
+                    self.get_logger().info(f"Waiting for service: {name}")
+                    has_logged_wait = True
         
         self.get_logger().info("All services available")
 
@@ -527,8 +530,8 @@ class MissionRunner(Node):
             return
         
         lat, lon, alt = self.current_target_coords
-        self.get_logger().info(f"Flying to target: lat={lat:.6f}, lon={lon:.6f}")
         cls_name = COCO_CLASS_NAMES[self.current_target_class_id] if self.current_target_class_id is not None and self.current_target_class_id < len(COCO_CLASS_NAMES) else 'unknown'
+        self.get_logger().info(f"Flying to {cls_name}: lat={lat:.6f}, lon={lon:.6f}")
         self.log.event('DELIVER_TARGET',
             f"lat={lat:.6f}, lon={lon:.6f}, class={cls_name}({self.current_target_class_id})")
 
@@ -717,9 +720,15 @@ class MissionRunner(Node):
         """Request object localization from vision node."""
         request = LocalizeObject.Request()
         request.target_class_id = self.confirmed_detection_class_id
+        target_name = (
+            COCO_CLASS_NAMES[request.target_class_id]
+            if 0 <= request.target_class_id < len(COCO_CLASS_NAMES)
+            else 'any object'
+        )
         
         self.get_logger().info(
-            f"Requesting localization from vision node (target_class_id={request.target_class_id})..."
+            f"Requesting localization from vision node for {target_name} "
+            f"(class_id={request.target_class_id})..."
         )
         
         future = self.localize_object_client.call_async(request)
@@ -781,7 +790,7 @@ class MissionRunner(Node):
                 f"ignore_radius=0.0001deg")
             self.get_logger().info(
                 f"Published deployed object location: lat={lat:.6f}, lon={lon:.6f}, "
-                f"class_id={deployed_msg.class_id}"
+                f"class={cls_name}({deployed_msg.class_id})"
             )
 
         self.objects_delivered_count += 1
@@ -949,9 +958,14 @@ class MissionRunner(Node):
 
         self.current_target_coords = (response.latitude, response.longitude, response.altitude)
         self.current_target_class_id = int(response.class_id)
+        cls_name = (
+            COCO_CLASS_NAMES[self.current_target_class_id]
+            if 0 <= self.current_target_class_id < len(COCO_CLASS_NAMES)
+            else 'unknown'
+        )
         
         self.get_logger().info(
-            f"Object localized at: lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
+            f"Localized {cls_name} at: lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
             f"alt={response.altitude:.2f}m (class_id={response.class_id})"
         )
         

--- a/bv_core/mission_logger.py
+++ b/bv_core/mission_logger.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Centralized mission logger for bv_core drone nodes.
+
+Writes human-readable, one-line-per-event logs to a shared file.
+All nodes import this and create their own MissionLogger instance.
+Controlled by enable_mission_log in mission_params.yaml.
+"""
+
+import os
+import time
+import math
+import yaml
+from datetime import datetime
+
+# Default log directory — lives next to the bv_core Python package
+LOG_DIR = os.path.join(os.path.dirname(__file__), 'logs')
+
+
+def _load_mission_config() -> dict:
+    """Load mission_params.yaml from the installed share directory."""
+    from ament_index_python.packages import get_package_share_directory
+    config_path = os.path.join(
+        get_package_share_directory('bv_core'),
+        'config',
+        'mission_params.yaml'
+    )
+    with open(config_path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def _make_log_filename() -> str:
+    """Generate log filename from current time: mission_MM-DD_H-MMpm.log"""
+    now = datetime.now()
+    hour_12 = now.strftime('%I').lstrip('0')  # 1-12, no leading zero
+    minute = now.strftime('%M')
+    ampm = now.strftime('%p').lower()
+    month_day = now.strftime('%m-%d')
+    return f"mission_{month_day}_{hour_12}-{minute}{ampm}.log"
+
+
+def _deg_to_meters(lat1, lon1, lat2, lon2):
+    """Approximate distance in meters between two lat/lon points."""
+    dlat = (lat2 - lat1) * 111320.0
+    dlon = (lon2 - lon1) * 111320.0 * math.cos(math.radians((lat1 + lat2) / 2))
+    return math.sqrt(dlat ** 2 + dlon ** 2)
+
+
+class MissionLogger:
+    """
+    Human-readable mission logger. Each node creates one instance.
+
+    Usage:
+        self.log = MissionLogger('mission')
+        self.log.event('STATE_CHANGE', 'takeoff -> lap')
+    """
+
+    def __init__(self, node_name: str):
+        self._node_name = node_name
+        self._file = None
+        self._enabled = False
+        self._last_heartbeat_time = 0.0
+        self._last_frame_window_repr = None
+
+        try:
+            cfg = _load_mission_config()
+        except Exception:
+            return
+
+        if not cfg.get('enable_mission_log', False):
+            return
+
+        self._enabled = True
+        os.makedirs(LOG_DIR, exist_ok=True)
+        log_path = os.path.join(LOG_DIR, _make_log_filename())
+        self._file = open(log_path, 'a', buffering=1)
+
+    def _timestamp(self) -> str:
+        now = datetime.now()
+        return now.strftime('[%H:%M:%S.') + f'{now.microsecond // 1000:03d}]'
+
+    def _write(self, event_type: str, details: str):
+        if not self._enabled or self._file is None:
+            return
+        line = f"{self._timestamp()} [{self._node_name}] {event_type} | {details}\n"
+        self._file.write(line)
+
+    def event(self, event_type: str, details: str):
+        self._write(event_type, details)
+
+    def scan_heartbeat(self, drone_pos: tuple, speed: float, alt: float, no_det_seconds: float):
+        if not self._enabled:
+            return
+        now = time.monotonic()
+        if now - self._last_heartbeat_time < 5.0:
+            return
+        self._last_heartbeat_time = now
+        lat, lon = drone_pos
+        self._write(
+            'SCAN_HEARTBEAT',
+            f"pos=({lat:.4f},{lon:.4f}), speed={speed:.1f}m/s, alt={alt:.1f}, "
+            f"no_detections_for={no_det_seconds:.1f}s"
+        )
+
+    def detection_frame(self, frame_num: int, drone_pos: tuple, speed: float,
+                        detections: list, filtered_reasons: dict = None):
+        if not self._enabled or not detections:
+            return
+        if filtered_reasons is None:
+            filtered_reasons = {}
+        lat, lon = drone_pos
+        parts = [f"frame={frame_num}, pos=({lat:.4f},{lon:.4f}), speed={speed:.1f}m/s, dets={len(detections)}"]
+        for i, det in enumerate(detections):
+            entry = (
+                f"{det['class_name']}({det['confidence']:.2f}) "
+                f"px=({det['px'][0]:.0f},{det['px'][1]:.0f}) -> "
+                f"({det['latlon'][0]:.4f},{det['latlon'][1]:.4f})"
+            )
+            reason = filtered_reasons.get(i, '')
+            if reason:
+                entry += f" {reason}"
+            parts.append(entry)
+        self._write('DETECTION_FRAME', ' | '.join(parts))
+
+    def frame_window(self, window_count: int, window_max: int, class_distances: dict):
+        if not self._enabled:
+            return
+        current_repr = f"{window_count}|{class_distances}"
+        if current_repr == self._last_frame_window_repr:
+            return
+        self._last_frame_window_repr = current_repr
+
+        parts = [f"window=[{window_count}/{window_max}]"]
+        for cls_name, info in class_distances.items():
+            dists = info.get('dists', [])
+            thresh = info.get('thresh', 0.0)
+            if dists:
+                dist_str = ','.join(f'{d:.1f}m' for d in dists)
+                parts.append(f"{cls_name}: dists=[{dist_str}] thresh={thresh:.1f}m")
+            else:
+                parts.append(f"{cls_name}: [frame0]")
+        self._write('FRAME_WINDOW', ' | '.join(parts))
+
+    def deploy_complete(self, class_id: int, class_name: str,
+                        target_pos: tuple, actual_pos: tuple,
+                        delivered_count: int, total: int):
+        if not self._enabled:
+            return
+        error_m = _deg_to_meters(target_pos[0], target_pos[1], actual_pos[0], actual_pos[1])
+        self._write(
+            'DEPLOY_COMPLETE',
+            f"class={class_name}({class_id}), "
+            f"target=({target_pos[0]:.6f},{target_pos[1]:.6f}), "
+            f"actual=({actual_pos[0]:.6f},{actual_pos[1]:.6f}), "
+            f"error={error_m:.1f}m, delivered={delivered_count}/{total}"
+        )
+
+    def close(self):
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/bv_core/stitching.py
+++ b/bv_core/stitching.py
@@ -44,6 +44,7 @@ class ImageStitcherNode(Node):
 
         #default to lap state at the beginning
         self.state = "lap"
+        self._was_stitching_active = False
 
         #default reached mode
         self.reached = False
@@ -100,12 +101,16 @@ class ImageStitcherNode(Node):
 
         # Helpers & buffer
         self.received_images = []
-        self.get_logger().info(f"Subscribed to {image_topic}`; stitch every {self.stitch_interval_sec}s")
 
     def state_callback(self, msg: String):
         try:
-            self.get_logger().info(f"Received State: state={msg.data}")
             self.state = msg.data
+            is_stitching_active = (self.state == "stitching")
+            if is_stitching_active and not self._was_stitching_active:
+                self.get_logger().info("Stitching active")
+            elif self._was_stitching_active and not is_stitching_active:
+                self.get_logger().info(f"Stitching inactive (state={self.state})")
+            self._was_stitching_active = is_stitching_active
         except Exception as e:
             self.get_logger().error(f"Failed to determine state")
 
@@ -113,7 +118,6 @@ class ImageStitcherNode(Node):
         if self.transition_in_progress:
             return
         idx = msg.wp_seq
-        self.get_logger().info(f'Reached waypoint {idx} (state={self.state})')
 
         #setting waypoint number
         self.waypoint_current = idx
@@ -126,10 +130,8 @@ class ImageStitcherNode(Node):
         #ask shankar if self.state can equal WaypointReached
         if (self.state == "stitching"): #or self.state == "lap" or self.state == "scan"):
             self.reached = True
-            self.get_logger().info(f'Reached waypoint in {self.state}')
         else: 
             self.reached = False
-            self.get_logger().info(f'Reached waypoint, NOT in stitching')
 
     def timer_callback(self):
         
@@ -147,7 +149,6 @@ class ImageStitcherNode(Node):
                 self.get_logger().info(f"Took picture number: {self.pic_counter}")
                 self.waypoint_prev = self.waypoint_current
                 self.received_images.append(self.latest_frame)
-                self.get_logger().info(f"Received frame: shape={self.latest_frame.shape} dtype={self.latest_frame.dtype} (buffer={len(self.received_images)})")
                 
                 ts = datetime.now().strftime("%Y%m%d_%H%M%S")
                 out_file = os.path.join(self.output_path, f"pic_{self.waypoint_current}.jpg")

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -445,16 +445,20 @@ class VisionNode(Node):
             if matched:
                 coords = matched
             else:
+                available_class_names = [
+                    COCO_CLASS_NAMES[int(c[2])] if 0 <= int(c[2]) < len(COCO_CLASS_NAMES) else f"class_{int(c[2])}"
+                    for c in coords
+                ]
                 self.get_logger().warn(
-                    f"Requested class {target_cls} not found in frame, "
-                    f"available: {[int(c[2]) for c in coords]}"
+                    f"Requested object '{target_name}' not found in frame; "
+                    f"detected: {available_class_names}"
                 )
                 # Treat this as a localization failure so the mission
                 # can retry or abandon the object instead of flying to
                 # the wrong target.
                 self.log.event('LOCALIZE_RESULT',
-                    f"success=false, reason=class_not_in_frame, target={request.target_class_id}, "
-                    f"available={[int(c[2]) for c in coords]} | "
+                    f"success=false, reason=class_not_in_frame, target={target_name}({request.target_class_id}), "
+                    f"available={available_class_names} | "
                     f"drone_pos=({drone_pose[0]:.6f},{drone_pose[1]:.6f},{drone_pose[2]:.1f}), "
                     f"orientation=({drone_orientation[0]:.3f},{drone_orientation[1]:.3f},{drone_orientation[2]:.3f},{drone_orientation[3]:.3f})")
                 return response

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -360,7 +360,11 @@ class VisionNode(Node):
         response.longitude = 0.0
         response.altitude = 0.0
         response.class_id = -1
-        target_name = COCO_CLASS_NAMES[request.target_class_id] if request.target_class_id >= 0 and request.target_class_id < len(COCO_CLASS_NAMES) else 'any'
+        target_name = (
+            CLASS_NAMES[request.target_class_id]
+            if 0 <= request.target_class_id < len(CLASS_NAMES)
+            else 'any'
+        )
         self.log.event('LOCALIZE_REQUEST', f"target_class={target_name}({request.target_class_id})")
 
         # Ensure pipeline is running
@@ -454,7 +458,7 @@ class VisionNode(Node):
                 coords = matched
             else:
                 available_class_names = [
-                    COCO_CLASS_NAMES[int(c[2])] if 0 <= int(c[2]) < len(COCO_CLASS_NAMES) else f"class_{int(c[2])}"
+                    CLASS_NAMES[int(c[2])] if 0 <= int(c[2]) < len(CLASS_NAMES) else f"class_{int(c[2])}"
                     for c in coords
                 ]
                 self.get_logger().warn(
@@ -479,7 +483,7 @@ class VisionNode(Node):
         response.class_id = int(coords[0][2])
         self.log.event('LOCALIZE_RESULT',
             f"success=true, lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
-            f"alt={response.altitude:.1f}, class={COCO_CLASS_NAMES[response.class_id]}({response.class_id}) | "
+            f"alt={response.altitude:.1f}, class={CLASS_NAMES[response.class_id] if 0 <= response.class_id < len(CLASS_NAMES) else 'unknown'}({response.class_id}) | "
             f"drone_pos=({drone_pose[0]:.6f},{drone_pose[1]:.6f},{drone_pose[2]:.1f}), "
             f"orientation=({drone_orientation[0]:.3f},{drone_orientation[1]:.3f},{drone_orientation[2]:.3f},{drone_orientation[3]:.3f})")
 
@@ -647,7 +651,7 @@ class VisionNode(Node):
                 detections.xyxy, detections.confidence, detections.class_id
             ):
                 det_list.append({
-                    'class_name': COCO_CLASS_NAMES[int(cls)],
+                    'class_name': CLASS_NAMES[int(cls)] if 0 <= int(cls) < len(CLASS_NAMES) else 'unknown',
                     'class_id': int(cls),
                     'confidence': float(score),
                     'px': ((x1 + x2) / 2.0, (y1 + y2) / 2.0),

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -40,6 +40,7 @@ from collections import deque
 from .detectors import create_detector
 from .pipelines import create_pipeline
 from .localizer import Localizer
+from .mission_logger import MissionLogger
 
 # ROS2 utilities
 from ament_index_python.packages import get_package_share_directory
@@ -73,6 +74,9 @@ class VisionNode(Node):
 
         self._load_config()
         self._init_state()
+        self.log = MissionLogger('vision')
+        self._frame_counter = 0
+        self._last_detection_time = time.monotonic()
         self._init_pipeline()
         self._init_threading()
         self._init_subscribers()
@@ -352,7 +356,9 @@ class VisionNode(Node):
         response.longitude = 0.0
         response.altitude = 0.0
         response.class_id = -1
-        
+        target_name = COCO_CLASS_NAMES[request.target_class_id] if request.target_class_id >= 0 and request.target_class_id < len(COCO_CLASS_NAMES) else 'any'
+        self.log.event('LOCALIZE_REQUEST', f"target_class={target_name}({request.target_class_id})")
+
         # Ensure pipeline is running
         if not self.pipeline_running:
             try:
@@ -360,6 +366,7 @@ class VisionNode(Node):
                 self.pipeline_running = True
             except RuntimeError as exc:
                 self.get_logger().error(f"Failed to start pipeline for localization: {exc}")
+                self.log.event('LOCALIZE_RESULT', f"success=false, reason=pipeline_start_failed")
                 return response
         
         # Capture frame
@@ -367,10 +374,12 @@ class VisionNode(Node):
             frame = self.pipeline.get_frame(timeout=1.0)
         except RuntimeError:
             self.get_logger().error("Failed to capture frame for localization")
+            self.log.event('LOCALIZE_RESULT', f"success=false, reason=no_frame")
             return response
         
         if frame is None:
             self.get_logger().error("No frame captured for localization")
+            self.log.event('LOCALIZE_RESULT', f"success=false, reason=no_frame")
             return response
         
         # Convert grayscale to BGR if needed
@@ -386,6 +395,7 @@ class VisionNode(Node):
         
         if len(detections) == 0:
             self.get_logger().warn("No detections found during localization")
+            self.log.event('LOCALIZE_RESULT', f"success=false, reason=no_detections")
             return response
         
         # Get pixel centers: (center_x, center_y, class_id)
@@ -397,6 +407,7 @@ class VisionNode(Node):
         # Check for sensor data
         if len(self.gps_buffer) == 0 or len(self.pose_buffer) == 0 or self.last_rel_alt is None:
             self.get_logger().error("Missing sensor data for localization")
+            self.log.event('LOCALIZE_RESULT', f"success=false, reason=missing_sensor_data")
             return response
         
         # Get latest drone pose
@@ -416,6 +427,10 @@ class VisionNode(Node):
         
         if not coords:
             self.get_logger().warn("Localization conversion failed")
+            self.log.event('LOCALIZE_RESULT',
+                f"success=false, reason=conversion_failed | "
+                f"drone_pos=({drone_pose[0]:.6f},{drone_pose[1]:.6f},{drone_pose[2]:.1f}), "
+                f"orientation=({drone_orientation[0]:.3f},{drone_orientation[1]:.3f},{drone_orientation[2]:.3f},{drone_orientation[3]:.3f})")
             return response
 
         target_cls = request.target_class_id
@@ -437,6 +452,11 @@ class VisionNode(Node):
                 # Treat this as a localization failure so the mission
                 # can retry or abandon the object instead of flying to
                 # the wrong target.
+                self.log.event('LOCALIZE_RESULT',
+                    f"success=false, reason=class_not_in_frame, target={request.target_class_id}, "
+                    f"available={[int(c[2]) for c in coords]} | "
+                    f"drone_pos=({drone_pose[0]:.6f},{drone_pose[1]:.6f},{drone_pose[2]:.1f}), "
+                    f"orientation=({drone_orientation[0]:.3f},{drone_orientation[1]:.3f},{drone_orientation[2]:.3f},{drone_orientation[3]:.3f})")
                 return response
 
         # At this point we have at least one coordinate to return
@@ -445,7 +465,12 @@ class VisionNode(Node):
         response.longitude = coords[0][1]
         response.altitude = drone_pose[2]
         response.class_id = int(coords[0][2])
-        
+        self.log.event('LOCALIZE_RESULT',
+            f"success=true, lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
+            f"alt={response.altitude:.1f}, class={COCO_CLASS_NAMES[response.class_id]}({response.class_id}) | "
+            f"drone_pos=({drone_pose[0]:.6f},{drone_pose[1]:.6f},{drone_pose[2]:.1f}), "
+            f"orientation=({drone_orientation[0]:.3f},{drone_orientation[1]:.3f},{drone_orientation[2]:.3f},{drone_orientation[3]:.3f})")
+
         return response
 
     
@@ -458,6 +483,7 @@ class VisionNode(Node):
             try:
                 self.pipeline.start()
                 self.pipeline_running = True
+                self.log.event('PIPELINE_START', f"type={self.pipeline_type}, trigger={self.state}")
             except RuntimeError as exc:
                 self.get_logger().error(f"Failed to start vision pipeline: {exc}")
                 self.state = self.prev_state
@@ -472,6 +498,7 @@ class VisionNode(Node):
         if self.pipeline_running:
             self.pipeline.stop()
             self.pipeline_running = False
+            self.log.event('PIPELINE_STOP', f"trigger={self.state}")
 
         # Flush any blocking queue.get() calls
         self.queue.put(None)
@@ -592,6 +619,41 @@ class VisionNode(Node):
             overlap=self.overlap
         )
 
+        # Log to mission logger
+        if len(detections) > 0:
+            self._frame_counter += 1
+            self._last_detection_time = time.monotonic()
+            drone_pos = (0.0, 0.0)
+            if len(self.gps_buffer) > 0:
+                g = self.gps_buffer[-1]
+                drone_pos = (g.latitude, g.longitude)
+            det_list = []
+            for (x1, y1, x2, y2), score, cls in zip(
+                detections.xyxy, detections.confidence, detections.class_id
+            ):
+                det_list.append({
+                    'class_name': COCO_CLASS_NAMES[int(cls)],
+                    'class_id': int(cls),
+                    'confidence': float(score),
+                    'px': ((x1 + x2) / 2.0, (y1 + y2) / 2.0),
+                    'latlon': (0.0, 0.0),  # geolocation done by filtering_node
+                })
+            filtered = {}
+            for i, det in enumerate(det_list):
+                if det['confidence'] <= self.det_thresh:
+                    filtered[i] = f"[BELOW_THRESH conf={det['confidence']:.2f} thresh={self.det_thresh:.2f}]"
+            self.log.detection_frame(self._frame_counter, drone_pos, 0.0, det_list, filtered)
+        else:
+            # Heartbeat when no detections during scan
+            if self.state == 'scan':
+                alt = self.last_rel_alt.data if self.last_rel_alt is not None else 0.0
+                drone_pos = (0.0, 0.0)
+                if len(self.gps_buffer) > 0:
+                    g = self.gps_buffer[-1]
+                    drone_pos = (g.latitude, g.longitude)
+                elapsed = time.monotonic() - self._last_detection_time
+                self.log.scan_heartbeat(drone_pos, 0.0, alt, elapsed)
+
         # Annotate frame using supervision
         labels = [
             f"{COCO_CLASS_NAMES[int(class_id)]} {confidence:.2f}"
@@ -640,6 +702,7 @@ class VisionNode(Node):
         self.detector.stop()
         self.queue.put(None)  # Unblock worker thread
 
+        self.log.close()
         return super().destroy_node()
 
 

--- a/config/mission_params.yaml
+++ b/config/mission_params.yaml
@@ -87,3 +87,7 @@ Deliver_tolerance: 1.0  # Tight - need accurate drop position
 Default_servo_pwms: [1500, 1500, 1500, 1500]    # Neutral position
 Deliver_initial_pwms: [1600, 1600, 1600, 1600]  # Release position
 Deliver_second_pwms: [1400, 1400, 1400, 1400]   # Retract position
+
+# MISSION LOGGING
+# Set to true to write detailed mission logs to bv_core/logs/
+enable_mission_log: true

--- a/test/test_mission_logger.py
+++ b/test/test_mission_logger.py
@@ -2,19 +2,26 @@
 """Tests for MissionLogger — no ROS dependencies required."""
 
 import os
-import tempfile
-import math
+import sys
+import re
 import pytest
 from unittest.mock import patch
+
+# Add the package root to sys.path so bv_core is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# Import after path setup, but patch _load_mission_config before any MissionLogger
+# is instantiated (it's called in __init__, not at module level)
+import bv_core.mission_logger as ml_module
+from bv_core.mission_logger import MissionLogger, _deg_to_meters
 
 
 class TestMissionLoggerDisabled:
     """When enable_mission_log is false, all methods are no-ops."""
 
     def test_no_file_created_when_disabled(self, tmp_path):
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': False}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
+        with patch.object(ml_module, '_load_mission_config', return_value={'enable_mission_log': False}):
+            with patch.object(ml_module, 'LOG_DIR', str(tmp_path / 'logs')):
                 log = MissionLogger('test_node')
                 log.event('STARTUP', 'num_objects=2')
                 log_dir = tmp_path / 'logs'
@@ -25,76 +32,74 @@ class TestMissionLoggerDisabled:
 class TestMissionLoggerEnabled:
     """When enable_mission_log is true, events are written to file."""
 
+    def _make_logger(self, tmp_path, node_name='mission'):
+        with patch.object(ml_module, '_load_mission_config', return_value={'enable_mission_log': True}):
+            with patch.object(ml_module, 'LOG_DIR', str(tmp_path / 'logs')):
+                return MissionLogger(node_name)
+
     def test_event_writes_line(self, tmp_path):
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
-                log = MissionLogger('mission')
-                log.event('STARTUP', 'num_objects=2')
-                log_dir = tmp_path / 'logs'
-                files = list(log_dir.iterdir())
-                assert len(files) == 1
-                content = files[0].read_text()
-                assert '[mission] STARTUP | num_objects=2' in content
+        log = self._make_logger(tmp_path)
+        log.event('STARTUP', 'num_objects=2')
+        log_dir = tmp_path / 'logs'
+        files = list(log_dir.iterdir())
+        assert len(files) == 1
+        content = files[0].read_text()
+        assert '[mission] STARTUP | num_objects=2' in content
 
     def test_event_format_has_timestamp(self, tmp_path):
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
-                log = MissionLogger('vision')
-                log.event('PIPELINE_START', 'type=real')
-                log_dir = tmp_path / 'logs'
-                content = list(log_dir.iterdir())[0].read_text()
-                import re
-                assert re.search(r'\[\d{2}:\d{2}:\d{2}\.\d{3}\]', content)
+        log = self._make_logger(tmp_path, 'vision')
+        log.event('PIPELINE_START', 'type=real')
+        log_dir = tmp_path / 'logs'
+        content = list(log_dir.iterdir())[0].read_text()
+        assert re.search(r'\[\d{2}:\d{2}:\d{2}\.\d{3}\]', content)
 
     def test_frame_window_deduplication(self, tmp_path):
         """frame_window should not write if content unchanged."""
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
-                log = MissionLogger('filtering')
-                window_data = {0: {'person': {'dists': [0.3], 'thresh': 5.5}}}
-                log.frame_window(1, 3, window_data)
-                log.frame_window(1, 3, window_data)  # same content
-                log_dir = tmp_path / 'logs'
-                content = list(log_dir.iterdir())[0].read_text()
-                assert content.count('FRAME_WINDOW') == 1
+        log = self._make_logger(tmp_path, 'filtering')
+        window_data = {'person': {'dists': [0.3], 'thresh': 5.5}}
+        log.frame_window(1, 3, window_data)
+        log.frame_window(1, 3, window_data)  # same content
+        log_dir = tmp_path / 'logs'
+        content = list(log_dir.iterdir())[0].read_text()
+        assert content.count('FRAME_WINDOW') == 1
 
     def test_scan_heartbeat_throttle(self, tmp_path):
         """scan_heartbeat should only write every ~5s."""
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
-                log = MissionLogger('vision')
-                log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.0)
-                log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.5)
-                log_dir = tmp_path / 'logs'
-                content = list(log_dir.iterdir())[0].read_text()
-                assert content.count('SCAN_HEARTBEAT') == 1
+        log = self._make_logger(tmp_path, 'vision')
+        log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.0)
+        log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.5)
+        log_dir = tmp_path / 'logs'
+        content = list(log_dir.iterdir())[0].read_text()
+        assert content.count('SCAN_HEARTBEAT') == 1
 
     def test_deploy_complete_calculates_error(self, tmp_path):
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
-                log = MissionLogger('mission')
-                log.deploy_complete(0, 'person', (38.387, -76.419), (38.387, -76.419), 1, 2)
-                log_dir = tmp_path / 'logs'
-                content = list(log_dir.iterdir())[0].read_text()
-                assert 'error=0.0m' in content
+        log = self._make_logger(tmp_path)
+        log.deploy_complete(0, 'person', (38.387, -76.419), (38.387, -76.419), 1, 2)
+        log_dir = tmp_path / 'logs'
+        content = list(log_dir.iterdir())[0].read_text()
+        assert 'error=0.0m' in content
 
     def test_multiple_nodes_same_file(self, tmp_path):
         """Two logger instances with different node names write to same file."""
-        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
-            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
-                from bv_core.mission_logger import MissionLogger
+        with patch.object(ml_module, '_load_mission_config', return_value={'enable_mission_log': True}):
+            with patch.object(ml_module, 'LOG_DIR', str(tmp_path / 'logs')):
                 log1 = MissionLogger('mission')
                 log2 = MissionLogger('vision')
-                log1.event('STATE_CHANGE', 'takeoff -> lap')
-                log2.event('PIPELINE_START', 'type=real')
-                log_dir = tmp_path / 'logs'
-                files = list(log_dir.iterdir())
-                assert len(files) == 1
-                content = files[0].read_text()
-                assert '[mission] STATE_CHANGE' in content
-                assert '[vision] PIPELINE_START' in content
+        log1.event('STATE_CHANGE', 'takeoff -> lap')
+        log2.event('PIPELINE_START', 'type=real')
+        log_dir = tmp_path / 'logs'
+        files = list(log_dir.iterdir())
+        assert len(files) == 1
+        content = files[0].read_text()
+        assert '[mission] STATE_CHANGE' in content
+        assert '[vision] PIPELINE_START' in content
+
+
+class TestDegToMeters:
+    def test_same_point_is_zero(self):
+        assert _deg_to_meters(38.0, -76.0, 38.0, -76.0) == 0.0
+
+    def test_known_distance(self):
+        # ~111m per 0.001 degree latitude
+        dist = _deg_to_meters(38.0, -76.0, 38.001, -76.0)
+        assert 110 < dist < 112

--- a/test/test_mission_logger.py
+++ b/test/test_mission_logger.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Tests for MissionLogger — no ROS dependencies required."""
+
+import os
+import tempfile
+import math
+import pytest
+from unittest.mock import patch
+
+
+class TestMissionLoggerDisabled:
+    """When enable_mission_log is false, all methods are no-ops."""
+
+    def test_no_file_created_when_disabled(self, tmp_path):
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': False}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('test_node')
+                log.event('STARTUP', 'num_objects=2')
+                log_dir = tmp_path / 'logs'
+                if log_dir.exists():
+                    assert len(list(log_dir.iterdir())) == 0
+
+
+class TestMissionLoggerEnabled:
+    """When enable_mission_log is true, events are written to file."""
+
+    def test_event_writes_line(self, tmp_path):
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('mission')
+                log.event('STARTUP', 'num_objects=2')
+                log_dir = tmp_path / 'logs'
+                files = list(log_dir.iterdir())
+                assert len(files) == 1
+                content = files[0].read_text()
+                assert '[mission] STARTUP | num_objects=2' in content
+
+    def test_event_format_has_timestamp(self, tmp_path):
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('vision')
+                log.event('PIPELINE_START', 'type=real')
+                log_dir = tmp_path / 'logs'
+                content = list(log_dir.iterdir())[0].read_text()
+                import re
+                assert re.search(r'\[\d{2}:\d{2}:\d{2}\.\d{3}\]', content)
+
+    def test_frame_window_deduplication(self, tmp_path):
+        """frame_window should not write if content unchanged."""
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('filtering')
+                window_data = {0: {'person': {'dists': [0.3], 'thresh': 5.5}}}
+                log.frame_window(1, 3, window_data)
+                log.frame_window(1, 3, window_data)  # same content
+                log_dir = tmp_path / 'logs'
+                content = list(log_dir.iterdir())[0].read_text()
+                assert content.count('FRAME_WINDOW') == 1
+
+    def test_scan_heartbeat_throttle(self, tmp_path):
+        """scan_heartbeat should only write every ~5s."""
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('vision')
+                log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.0)
+                log.scan_heartbeat((38.387, -76.419), 2.4, 45.7, 5.5)
+                log_dir = tmp_path / 'logs'
+                content = list(log_dir.iterdir())[0].read_text()
+                assert content.count('SCAN_HEARTBEAT') == 1
+
+    def test_deploy_complete_calculates_error(self, tmp_path):
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log = MissionLogger('mission')
+                log.deploy_complete(0, 'person', (38.387, -76.419), (38.387, -76.419), 1, 2)
+                log_dir = tmp_path / 'logs'
+                content = list(log_dir.iterdir())[0].read_text()
+                assert 'error=0.0m' in content
+
+    def test_multiple_nodes_same_file(self, tmp_path):
+        """Two logger instances with different node names write to same file."""
+        with patch('bv_core.mission_logger._load_mission_config', return_value={'enable_mission_log': True}):
+            with patch('bv_core.mission_logger.LOG_DIR', str(tmp_path / 'logs')):
+                from bv_core.mission_logger import MissionLogger
+                log1 = MissionLogger('mission')
+                log2 = MissionLogger('vision')
+                log1.event('STATE_CHANGE', 'takeoff -> lap')
+                log2.event('PIPELINE_START', 'type=real')
+                log_dir = tmp_path / 'logs'
+                files = list(log_dir.iterdir())
+                assert len(files) == 1
+                content = files[0].read_text()
+                assert '[mission] STATE_CHANGE' in content
+                assert '[vision] PIPELINE_START' in content


### PR DESCRIPTION
## Summary

This branch adds a centralized mission log file, integrates it into the mission stack, and cleans up operator-facing console logs so mission output is easier to follow during flight and after review.

It has also been merged with `main` while keeping `main`'s mission/filtering logic intact. The remaining branch changes are focused on logging.

## What Changed

- Added `bv_core/mission_logger.py`, a shared file-based logger for mission events.
- Integrated mission logging into:
  - `bv_core/mission.py`
  - `bv_core/vision_node.py`
  - `bv_core/filtering_node.py`
- Added structured mission log events for:
  - startup and home set
  - state changes
  - waypoint reached
  - localization request/result
  - object confirmed / rejected
  - deploy steps and deployed location
  - scan resume and scan heartbeat
- Added `enable_mission_log` to `config/mission_params.yaml`.
- Added unit tests in `test/test_mission_logger.py`.

## Console Log Cleanup

- Reduced repeated `Waiting for service: ...` output in `mission.py` so each unavailable service is only announced once while waiting.
- Changed the localizer empty-frame warning to the more human-readable `No objects detected in frame` and deduped it across consecutive empty frames.
- Changed filtering-node frame-window output to a human-readable summary and only print when the summary changes.
- Updated mission and vision logging to use the same `person` / `tent` class naming logic as `main`.
- Removed `class_id=` from the human-facing mission localization request/success console logs.
- Removed redundant stitching waypoint logs and replaced them with one-time state transition logs:
  - `Stitching active`
  - `Stitching inactive (state=...)`
- Removed low-value stitching debug logs such as `Subscribed to ...` and `Received frame: shape=... dtype=...`.

## Why

- Makes the mission output easier for an operator to understand in real time.
- Reduces repeated/noisy logs from polling loops and high-frequency callbacks.
- Adds a persistent post-flight log with the key mission decisions in one place.
- Keeps naming aligned with `main` so the log output matches the existing `person` / `tent` target logic.

## Mission Log Parameter

Mission file logging is controlled by `enable_mission_log` in `config/mission_params.yaml`:

```yaml
enable_mission_log: true
```

Set it to `false` to disable mission file logging.

When enabled, logs are written under `bv_core/logs/` with filenames like `mission_MM-DD_H-MMpm.log`.

## Validation

- `pytest -q test/test_mission_logger.py`
- `python3 -m compileall bv_core/mission.py bv_core/vision_node.py bv_core/stitching.py`
