### PR TITLE
Simplify filtering and switch ML detector to LTDETR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ End-to-end autonomy stack for BV missions: mission control, vision-based detecti
 
 This package orchestrates an autonomous mission with PX4:
 - Mission node pushes waypoints, arms, and switches to AUTO.MISSION.
-- Vision node captures frames during scan legs, runs RF-DETR, and publishes detections.
+- Vision node captures frames during scan legs, runs LTDETR, and publishes detections.
 - Filtering node fuses detections with pose/GPS to estimate object lat/lon and serves them to Mission.
 - Stitching node captures images at waypoints to build an aerial map.
 
@@ -21,7 +21,7 @@ bv_ws
 ├── build
 ├── install
 ├── log
-├── rf-detr-base.pth
+├── ltdetr.pt
 └── src
     ├── bv_core
     └── bv_msgs
@@ -35,7 +35,7 @@ bv_ws
 ├── build
 ├── install
 ├── log
-├── rf-detr-base.pth
+├── ltdetr.pt
 └── src
     ├── bv_core
     ├── bv_msgs
@@ -61,7 +61,7 @@ High-level services (“microservices”) and data flow:
 - vision_node (bv_core.vision_node.VisionNode)
 	- Publishes: `/obj_dets` (bv_msgs/ObjectDetections), `/queue_state` (std_msgs/Int8)
 	- Subscribes: `/image_raw` (sensor_msgs/Image), `/mission_state` (String), `/mavros/mission/reached` (WaypointReached)
-	- Role: On scan state, enqueue frames at each reach event, infer with RF-DETR in batches, annotate/save frames, publish detections.
+	- Role: On scan state, enqueue frames at each reach event, infer with LTDETR, annotate/save frames, publish detections.
 
 - filtering_node (bv_core.filtering_node.FilteringNode)
 	- Provides: `get_object_locations` (bv_msgs/srv/GetObjectLocations)
@@ -151,17 +151,11 @@ Prerequisites (Ubuntu 22.04 LTS recommended; typical dev machine or Jetson):
 - [GeographicLib](https://geographiclib.sourceforge.io/C++/doc/index.html)
 - [PX4_Autopilot](https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html)
 - download Render_CAD.stl into meshes/ folder [Render_CAD.STL](https://buckeyemailosu-my.sharepoint.com/:u:/g/personal/clute_25_buckeyemail_osu_edu/EcOCPRC-NQFAmV3IplgyZxwBzP3rijvungflwU5AE4Jchw?e=PTFW1S)
-- Python 3.10+ with CUDA-capable GPU recommended for RF-DETR.
+- Python 3.10+ with LightlyTrain support; CUDA-capable GPU recommended for LTDETR.
 
 Install python deps (setup a venv... I recommend uv):
 ```bash
 pip install -r requirements.txt
-```
-In the root of your ROS workspace (~/bv_ws) run:
-```bash
-git clone https://github.com/BuckeyeVertical/rf-detr.git
-cd rf-detr
-pip install -e .
 ```
 
 Install mavros:
@@ -197,7 +191,7 @@ Configuration files:
 	- Waypoint lists: `points` (lap), `scan_points`, `stitch_points`, `deliver_points`
 	- Velocities/tolerances: `Lap_velocity`, `Scan_velocity`, `Stitch_velocity`, `*_tolerance`
 - `config/vision_params.yaml`
-	- `batch_size`, `detection_threshold`, `resolution`, `overlap`, `capture_interval`, `num_scan_wp`
+	- `detection_threshold`, `capture_interval`, `num_scan_wp`, `detector_type`, `ml_model_path`
 - `config/filtering_params.yaml`
 	- `c_matrix` (intrinsics 3x3), `dist_coefficients` (k1…k5), `camera_orientation` (mount euler xyz in radians)
 
@@ -580,7 +574,7 @@ ros2 bag record -o bag_recording_1 \
 
 - No detections published
 	- Verify `/image_raw` is publishing.
-	- Ensure GPU/CUDA available for RF-DETR; adjust `batch_size`/`resolution` to fit memory.
+	- Ensure the configured `ml_model_path` exists and `lightly-train` is installed when using `detector_type: "ml"`.
 
 - Object locations empty
 	- Locations are finalized after leaving `scan` state; confirm `/mission_state` transitions.

--- a/bv_core/detectors/RFDETR_detector.py
+++ b/bv_core/detectors/RFDETR_detector.py
@@ -1,0 +1,200 @@
+"""ML-based object detector using RF-DETR."""
+
+import os
+
+import numpy as np
+import rclpy.logging
+import supervision as sv
+import torch
+from PIL import Image
+from rfdetr import RFDETRBase
+
+from .base_detector import BaseDetector
+
+
+class MLDetector(BaseDetector):
+    """Object detector using RF-DETR model with tiled inference."""
+
+    def __init__(self, batch_size: int = 16, resolution: int = 728):
+        """Initialize the ML detector.
+
+        Args:
+            batch_size: Number of tiles to process in parallel.
+            resolution: Input resolution for the model (tile size).
+        """
+        self.batch_size = batch_size
+        self.resolution = resolution
+        self.model = None
+        self.frame_save_cnt = 0
+
+    def start(self) -> None:
+        """Load the RF-DETR model."""
+        if self.model is None:
+            self.model = self._create_model()
+
+    def stop(self) -> None:
+        """Release model resources."""
+        self.model = None
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def process_frame(
+        self,
+        frame: np.ndarray,
+        overlap: int = 100,
+        threshold: float = 0.5,
+        **kwargs,
+    ) -> sv.Detections:
+        """Process an image by tiling, batched inference, and global NMS.
+
+        Args:
+            frame: Input image as numpy array (H, W, C).
+            overlap: Overlap between adjacent tiles in pixels.
+            threshold: Detection confidence threshold.
+
+        Returns:
+            Merged detections with NMS applied.
+        """
+        if self.model is None:
+            rclpy.logging.get_logger("ml_detector").info("Creating model")
+            self.model = self._create_model()
+
+        tiles_with_positions = self._create_tiles(frame, overlap)
+        tiles, offsets = zip(*tiles_with_positions)
+
+        detections_list = []
+        for i in range(0, len(tiles), self.batch_size):
+            batch = list(tiles[i : i + self.batch_size])
+            dets = self._pad_and_predict(batch, threshold)
+            detections_list.extend(dets)
+
+        all_dets = []
+        for dets, (x_off, y_off) in zip(detections_list, offsets):
+            if len(dets.xyxy) == 0:
+                continue
+
+            boxes = dets.xyxy.copy()
+            boxes[:, [0, 2]] += x_off
+            boxes[:, [1, 3]] += y_off
+
+            all_dets.append(
+                sv.Detections(
+                    xyxy=boxes,
+                    confidence=dets.confidence,
+                    class_id=dets.class_id,
+                )
+            )
+
+        if not all_dets:
+            return sv.Detections.empty()
+
+        merged = sv.Detections.merge(all_dets)
+        return merged.with_nms(threshold=0.45)
+
+    def annotate_frame(
+        self,
+        frame: np.ndarray,
+        detections: sv.Detections,
+        labels: list,
+    ) -> np.ndarray:
+        """Draw bounding boxes and labels on frame."""
+        annotated_frame = frame.copy()
+        annotated_frame = sv.BoxAnnotator().annotate(annotated_frame, detections)
+        annotated_frame = sv.LabelAnnotator().annotate(
+            annotated_frame, detections, labels
+        )
+        return annotated_frame
+
+    def save_frame(self, frame: np.ndarray, output_dir: str) -> None:
+        """Save annotated frame to disk."""
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, f"{self.frame_save_cnt}_annotated.jpg")
+        Image.fromarray(frame).save(output_path)
+        self.frame_save_cnt += 1
+
+    def _create_tiles(self, image: np.ndarray, overlap: int = 100) -> list:
+        """Split an image into overlapping tiles.
+
+        Args:
+            image: Input image as numpy array (H, W, C).
+            overlap: Overlap between adjacent tiles in pixels.
+
+        Returns:
+            List of (tile, (x_offset, y_offset)) tuples.
+        """
+        tile_size = self.resolution
+        width, height = image.shape[1], image.shape[0]
+        tiles = []
+
+        x_positions = list(range(0, width - overlap, tile_size - overlap))
+        if width not in x_positions and x_positions:
+            x_positions.append(max(0, width - tile_size))
+        if not x_positions:
+            x_positions = [0]
+
+        y_positions = list(range(0, height - overlap, tile_size - overlap))
+        if height not in y_positions and y_positions:
+            y_positions.append(max(0, height - tile_size))
+        if not y_positions:
+            y_positions = [0]
+
+        for y in y_positions:
+            for x in x_positions:
+                x_end = min(x + tile_size, width)
+                y_end = min(y + tile_size, height)
+                x_start = max(0, x_end - tile_size)
+                y_start = max(0, y_end - tile_size)
+
+                tile = image[y_start:y_end, x_start:x_end, :]
+                tiles.append((tile, (x_start, y_start)))
+
+        return tiles
+
+    def _pad_and_predict(self, tiles: list, threshold: float) -> list:
+        """Run batched inference, padding if needed.
+
+        Args:
+            tiles: List of tile images as numpy arrays.
+            threshold: Detection confidence threshold.
+
+        Returns:
+            List of detections for each tile.
+        """
+        B = len(tiles)
+        if B < self.batch_size:
+            dummy = np.zeros_like(tiles[0])
+            tiles = tiles + [dummy] * (self.batch_size - B)
+            trim_to = B
+        else:
+            trim_to = None
+
+        outputs = self.model.predict(tiles, threshold=threshold)
+
+        if trim_to is not None:
+            outputs = outputs[:trim_to]
+
+        return outputs
+
+    def _create_model(self, dtype=None):
+        """Initialize the RF-DETR model."""
+        if dtype is None:
+            if torch.cuda.is_available():
+                dtype = torch.float16
+            else:
+                dtype = torch.float32
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            device_info = "cuda"
+        else:
+            device_info = "cpu"
+
+        model = RFDETRBase(resolution=self.resolution)
+        model.optimize_for_inference(batch_size=self.batch_size, dtype=dtype)
+
+        rclpy.logging.get_logger("ml_detector").info(
+            f"Model created with batch size: {self.batch_size} "
+            f"(dtype={dtype}, device={device_info})"
+        )
+
+        return model

--- a/bv_core/detectors/__init__.py
+++ b/bv_core/detectors/__init__.py
@@ -2,12 +2,10 @@
 
 from .base_detector import BaseDetector
 from .gazebo_bbox_detector import GazeboBBoxDetector
-from .ml_detector import MLDetector
 
 __all__ = [
     "BaseDetector",
     "GazeboBBoxDetector",
-    "MLDetector",
     "create_detector",
 ]
 
@@ -17,7 +15,7 @@ def create_detector(detector_type: str, **config) -> BaseDetector:
 
     Args:
         detector_type: Type of detector to create. Options:
-            - "ml": ML-based detector using RF-DETR
+            - "ml": ML-based detector using LightlyTrain LTDETR
             - "gazebo_bbox": Gazebo bounding box camera detector
         **config: Configuration parameters passed to the detector constructor.
 
@@ -28,9 +26,13 @@ def create_detector(detector_type: str, **config) -> BaseDetector:
         ValueError: If detector_type is unknown.
     """
     if detector_type == "ml":
+        from .ml_detector import MLDetector
+
         return MLDetector(
-            batch_size=config.get("batch_size", 16),
-            resolution=config.get("resolution", 728),
+            model_path=config.get(
+                "ml_model_path",
+                "/Users/allenthomas/Code/Personal/inference/ltdetr.pt",
+            ),
         )
     elif detector_type == "gazebo_bbox":
         return GazeboBBoxDetector(

--- a/bv_core/detectors/__init__.py
+++ b/bv_core/detectors/__init__.py
@@ -1,13 +1,21 @@
 """Pluggable object detection backends."""
 
 from .base_detector import BaseDetector
-from .gazebo_bbox_detector import GazeboBBoxDetector
 
 __all__ = [
     "BaseDetector",
     "GazeboBBoxDetector",
     "create_detector",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily import detector backends with heavy runtime dependencies."""
+    if name == "GazeboBBoxDetector":
+        from .gazebo_bbox_detector import GazeboBBoxDetector
+
+        return GazeboBBoxDetector
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def create_detector(detector_type: str, **config) -> BaseDetector:
@@ -35,6 +43,8 @@ def create_detector(detector_type: str, **config) -> BaseDetector:
             ),
         )
     elif detector_type == "gazebo_bbox":
+        from .gazebo_bbox_detector import GazeboBBoxDetector
+
         return GazeboBBoxDetector(
             topic=config.get("gazebo_bbox_topic", "/camera/bounding_boxes"),
             queue_size=config.get("queue_size", 5),

--- a/bv_core/detectors/gazebo_bbox_detector.py
+++ b/bv_core/detectors/gazebo_bbox_detector.py
@@ -10,20 +10,9 @@ from gz.transport13 import Node as GzNode
 from gz.msgs10.annotated_axis_aligned_2d_box_v_pb2 import AnnotatedAxisAligned2DBox_V
 
 from .base_detector import BaseDetector
-import logging
 
 
-# Mapping from Gazebo label IDs (set via gz-sim-label-system plugin) to COCO class IDs
-# This mapping should match the <label> tags in your world SDF file
-GAZEBO_LABEL_TO_COCO = {
-    0: 2,    # hatchback_red (car) -> COCO "car" (class 2)
-    1: 32,   # ball -> COCO "sports ball" (class 32)
-    2: 4,    # rc_cessna (airplane) -> COCO "airplane" (class 4)
-    3: 0,    # person -> COCO "person" (class 0)
-    4: 5,    # bus -> COCO "bus" (class 5)
-    5: 11,   # stop_sign -> COCO "stop sign" (class 11)
-    6: 28,   # suitcase -> COCO "suitcase" (class 28)
-}
+CLASS_NAMES = ("person", "tent")
 
 
 class GazeboBBoxDetector(BaseDetector):
@@ -163,11 +152,11 @@ class GazeboBBoxDetector(BaseDetector):
         confidences = []
 
         for box in boxes:
-            # box.label contains the numeric label from gz-sim-label-system plugin
-            # Map it to COCO class ID using our mapping table
-            gazebo_label = box.label
-            coco_class_id = GAZEBO_LABEL_TO_COCO.get(gazebo_label, 0)  # Default to person (0) if unknown
-            
+            # box.label comes directly from the Gazebo label plugin.
+            class_id = int(box.label)
+            if class_id < 0 or class_id >= len(CLASS_NAMES):
+                continue
+
             bbox = box.box
 
             x_min = bbox.min_corner.x
@@ -184,7 +173,7 @@ class GazeboBBoxDetector(BaseDetector):
                 continue
 
             xyxy_list.append([x_min, y_min, x_max, y_max])
-            class_ids.append(coco_class_id)
+            class_ids.append(class_id)
             confidences.append(1.0)
 
         if not xyxy_list:

--- a/bv_core/detectors/ml_detector.py
+++ b/bv_core/detectors/ml_detector.py
@@ -1,200 +1,101 @@
-"""ML-based object detector using RF-DETR."""
+"""ML-based object detector using LightlyTrain LTDETR."""
 
-import os
+from pathlib import Path
 
 import numpy as np
 import rclpy.logging
 import supervision as sv
-import torch
-from PIL import Image
-from rfdetr import RFDETRBase
 
 from .base_detector import BaseDetector
 
 
 class MLDetector(BaseDetector):
-    """Object detector using RF-DETR model with tiled inference."""
+    """Object detector using a LightlyTrain LTDETR checkpoint."""
 
-    def __init__(self, batch_size: int = 16, resolution: int = 728):
+    def __init__(self, model_path: str):
         """Initialize the ML detector.
 
         Args:
-            batch_size: Number of tiles to process in parallel.
-            resolution: Input resolution for the model (tile size).
+            model_path: Filesystem path to the LTDETR checkpoint.
         """
-        self.batch_size = batch_size
-        self.resolution = resolution
+        self.model_path = Path(model_path).expanduser()
         self.model = None
-        self.frame_save_cnt = 0
+        self._logger = rclpy.logging.get_logger("ml_detector")
 
     def start(self) -> None:
-        """Load the RF-DETR model."""
+        """Load the LTDETR model."""
         if self.model is None:
             self.model = self._create_model()
 
     def stop(self) -> None:
         """Release model resources."""
         self.model = None
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
 
     def process_frame(
         self,
         frame: np.ndarray,
-        overlap: int = 100,
         threshold: float = 0.5,
         **kwargs,
     ) -> sv.Detections:
-        """Process an image by tiling, batched inference, and global NMS.
+        """Run LTDETR inference on a single frame.
 
         Args:
-            frame: Input image as numpy array (H, W, C).
-            overlap: Overlap between adjacent tiles in pixels.
-            threshold: Detection confidence threshold.
+            frame: Input image as numpy array (H, W, C) in BGR format.
+            threshold: Minimum confidence required to keep a detection.
 
         Returns:
-            Merged detections with NMS applied.
+            Detections surviving confidence filtering.
         """
         if self.model is None:
-            rclpy.logging.get_logger("ml_detector").info("Creating model")
             self.model = self._create_model()
 
-        tiles_with_positions = self._create_tiles(frame, overlap)
-        tiles, offsets = zip(*tiles_with_positions)
+        from PIL import Image
 
-        detections_list = []
-        for i in range(0, len(tiles), self.batch_size):
-            batch = list(tiles[i : i + self.batch_size])
-            dets = self._pad_and_predict(batch, threshold)
-            detections_list.extend(dets)
+        image = Image.fromarray(frame[:, :, ::-1])
+        results = self.model.predict(image)
 
-        all_dets = []
-        for dets, (x_off, y_off) in zip(detections_list, offsets):
-            if len(dets.xyxy) == 0:
-                continue
+        labels = self._to_numpy(results.get("labels"), np.int32)
+        boxes = self._to_numpy(results.get("bboxes"), np.float32).reshape((-1, 4))
+        scores = self._to_numpy(results.get("scores"), np.float32)
 
-            boxes = dets.xyxy.copy()
-            boxes[:, [0, 2]] += x_off
-            boxes[:, [1, 3]] += y_off
-
-            all_dets.append(
-                sv.Detections(
-                    xyxy=boxes,
-                    confidence=dets.confidence,
-                    class_id=dets.class_id,
-                )
-            )
-
-        if not all_dets:
+        if len(labels) == 0 or len(boxes) == 0 or len(scores) == 0:
             return sv.Detections.empty()
 
-        merged = sv.Detections.merge(all_dets)
-        return merged.with_nms(threshold=0.45)
+        keep = scores >= float(threshold)
+        if not np.any(keep):
+            return sv.Detections.empty()
 
-    def annotate_frame(
-        self,
-        frame: np.ndarray,
-        detections: sv.Detections,
-        labels: list,
-    ) -> np.ndarray:
-        """Draw bounding boxes and labels on frame."""
-        annotated_frame = frame.copy()
-        annotated_frame = sv.BoxAnnotator().annotate(annotated_frame, detections)
-        annotated_frame = sv.LabelAnnotator().annotate(
-            annotated_frame, detections, labels
-        )
-        return annotated_frame
-
-    def save_frame(self, frame: np.ndarray, output_dir: str) -> None:
-        """Save annotated frame to disk."""
-        os.makedirs(output_dir, exist_ok=True)
-        output_path = os.path.join(output_dir, f"{self.frame_save_cnt}_annotated.jpg")
-        Image.fromarray(frame).save(output_path)
-        self.frame_save_cnt += 1
-
-    def _create_tiles(self, image: np.ndarray, overlap: int = 100) -> list:
-        """Split an image into overlapping tiles.
-
-        Args:
-            image: Input image as numpy array (H, W, C).
-            overlap: Overlap between adjacent tiles in pixels.
-
-        Returns:
-            List of (tile, (x_offset, y_offset)) tuples.
-        """
-        tile_size = self.resolution
-        width, height = image.shape[1], image.shape[0]
-        tiles = []
-
-        x_positions = list(range(0, width - overlap, tile_size - overlap))
-        if width not in x_positions and x_positions:
-            x_positions.append(max(0, width - tile_size))
-        if not x_positions:
-            x_positions = [0]
-
-        y_positions = list(range(0, height - overlap, tile_size - overlap))
-        if height not in y_positions and y_positions:
-            y_positions.append(max(0, height - tile_size))
-        if not y_positions:
-            y_positions = [0]
-
-        for y in y_positions:
-            for x in x_positions:
-                x_end = min(x + tile_size, width)
-                y_end = min(y + tile_size, height)
-                x_start = max(0, x_end - tile_size)
-                y_start = max(0, y_end - tile_size)
-
-                tile = image[y_start:y_end, x_start:x_end, :]
-                tiles.append((tile, (x_start, y_start)))
-
-        return tiles
-
-    def _pad_and_predict(self, tiles: list, threshold: float) -> list:
-        """Run batched inference, padding if needed.
-
-        Args:
-            tiles: List of tile images as numpy arrays.
-            threshold: Detection confidence threshold.
-
-        Returns:
-            List of detections for each tile.
-        """
-        B = len(tiles)
-        if B < self.batch_size:
-            dummy = np.zeros_like(tiles[0])
-            tiles = tiles + [dummy] * (self.batch_size - B)
-            trim_to = B
-        else:
-            trim_to = None
-
-        outputs = self.model.predict(tiles, threshold=threshold)
-
-        if trim_to is not None:
-            outputs = outputs[:trim_to]
-
-        return outputs
-
-    def _create_model(self, dtype=None):
-        """Initialize the RF-DETR model."""
-        if dtype is None:
-            if torch.cuda.is_available():
-                dtype = torch.float16
-            else:
-                dtype = torch.float32
-
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            device_info = "cuda"
-        else:
-            device_info = "cpu"
-
-        model = RFDETRBase(resolution=self.resolution)
-        model.optimize_for_inference(batch_size=self.batch_size, dtype=dtype)
-
-        rclpy.logging.get_logger("ml_detector").info(
-            f"Model created with batch size: {self.batch_size} "
-            f"(dtype={dtype}, device={device_info})"
+        return sv.Detections(
+            xyxy=boxes[keep],
+            confidence=scores[keep],
+            class_id=labels[keep],
         )
 
-        return model
+    def _create_model(self):
+        """Initialize the LTDETR model."""
+        if not self.model_path.is_file():
+            raise RuntimeError(f"LTDETR weights not found: {self.model_path}")
+
+        try:
+            import lightly_train
+        except ImportError as exc:
+            raise RuntimeError(
+                "Missing dependency 'lightly_train'. Install it with "
+                "`python3 -m pip install lightly-train`."
+            ) from exc
+
+        self._logger.info(f"Loading LTDETR model from {self.model_path}")
+        return lightly_train.load_model(str(self.model_path))
+
+    @staticmethod
+    def _to_numpy(value, dtype) -> np.ndarray:
+        """Convert LTDETR outputs to numpy arrays without hard-coding torch."""
+        if value is None:
+            return np.array([], dtype=dtype)
+        if hasattr(value, "detach"):
+            value = value.detach()
+        if hasattr(value, "cpu"):
+            value = value.cpu()
+        if hasattr(value, "numpy"):
+            value = value.numpy()
+        return np.asarray(value, dtype=dtype)

--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -10,15 +10,6 @@ from rclpy.executors import MultiThreadedExecutor
 from bv_msgs.msg import ObjectDetections
 from geometry_msgs.msg import PoseStamped
 import numpy as np
-from rfdetr.util.coco_classes import COCO_CLASSES
-
-# Create 0-indexed list from COCO_CLASSES (detector outputs 0-79, not original COCO IDs)
-COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
-
-# Only two target classes for the competition: one mannequin, one tent
-MANNEQUIN_CLASS_ID = COCO_CLASS_NAMES.index('person')
-TENT_CLASS_ID = COCO_CLASS_NAMES.index('umbrella')  # closest COCO class to tent
-TARGET_CLASS_IDS = {MANNEQUIN_CLASS_ID, TENT_CLASS_ID}
 
 from sensor_msgs.msg import NavSatFix
 
@@ -29,6 +20,9 @@ import os
 from collections import deque
 from rclpy.time import Time
 import math
+
+CLASS_NAMES = ("person", "tent")
+
 
 class FilteringNode(Node):
     def __init__(self):
@@ -92,10 +86,10 @@ class FilteringNode(Node):
         self.state = None
         
         # === target tracking ===
-        # One entry per competition target: mannequin and tent
+        # One entry per competition target: person and tent
         self.targets = {
-            MANNEQUIN_CLASS_ID: {"state": "undetected", "lat": None, "lon": None},
-            TENT_CLASS_ID:      {"state": "undetected", "lat": None, "lon": None},
+            class_id: {"state": "undetected", "lat": None, "lon": None}
+            for class_id in range(len(CLASS_NAMES))
         }
         
         # === 3-frame confirmation tracking ===
@@ -306,7 +300,11 @@ class FilteringNode(Node):
                 with open('finalized_object_locations.txt', 'w') as f:
                         for cls, info in self.targets.items():
                             if info["state"] == "deployed":
-                                class_name = COCO_CLASS_NAMES[int(cls)] if int(cls) >= 0 else "unknown"
+                                class_name = (
+                                    CLASS_NAMES[int(cls)]
+                                    if 0 <= int(cls) < len(CLASS_NAMES)
+                                    else "unknown"
+                                )
                                 f.write(f"{info['lat']:.6f},{info['lon']:.6f},{class_name}\n")
 
         self.prev_state = msg.data

--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -4,7 +4,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 
-from std_msgs.msg import String, Float64, Bool, Int8
+from std_msgs.msg import String, Float64, Int8
 from .localizer import Localizer
 from rclpy.executors import MultiThreadedExecutor
 from bv_msgs.msg import ObjectDetections
@@ -14,13 +14,18 @@ from rfdetr.util.coco_classes import COCO_CLASSES
 
 # Create 0-indexed list from COCO_CLASSES (detector outputs 0-79, not original COCO IDs)
 COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
+
+# Only two target classes for the competition: one mannequin, one tent
+MANNEQUIN_CLASS_ID = COCO_CLASS_NAMES.index('person')
+TENT_CLASS_ID = COCO_CLASS_NAMES.index('umbrella')  # closest COCO class to tent
+TARGET_CLASS_IDS = {MANNEQUIN_CLASS_ID, TENT_CLASS_ID}
+
 from sensor_msgs.msg import NavSatFix
 
 from bv_msgs.msg import ObjectLocations         # your custom msg
 import yaml
 from ament_index_python.packages import get_package_share_directory
 import os
-import time
 from collections import deque
 from rclpy.time import Time
 import math
@@ -83,14 +88,18 @@ class FilteringNode(Node):
         self.pose_buffer = deque(maxlen=200)
 
         # === internal state ===
-        self.global_dets = []   # list of (lat, lon, class_id) for all detections so far
         self.prev_state = None
         self.state = None
-        self.deployed_locations = []  # list of (lat, lon, class_id) for completed deployments
+        
+        # === target tracking ===
+        # One entry per competition target: mannequin and tent
+        self.targets = {
+            MANNEQUIN_CLASS_ID: {"state": "undetected", "lat": None, "lon": None},
+            TENT_CLASS_ID:      {"state": "undetected", "lat": None, "lon": None},
+        }
         
         # === 3-frame confirmation tracking ===
         self.frame_history = []  # list of recent detection sets [(lat, lon, class_id), ...]
-        self.already_confirmed_classes = set()  # avoid re-triggering same object
         
         # === publisher for confirmed detections ===
         # Use same reliable QoS pattern for /global_obj_dets
@@ -109,7 +118,6 @@ class FilteringNode(Node):
 
         c_mat_list = cfg.get('c_matrix', [1.0]*9)
         dist_coeff_list = cfg.get('dist_coefficients', [0.0]*5)
-        self.deployed_ignore_radius_deg = float(cfg.get('deployed_ignore_radius_deg', 0.00005))
 
         camera_matrix = np.array(c_mat_list, dtype=np.float64).reshape((3, 3))
         dist_coeffs = np.array(dist_coeff_list, dtype=np.float64)
@@ -120,7 +128,6 @@ class FilteringNode(Node):
         )
 
         self.last_rel_alt = None
-        self._last_window_print_time = 0.0
 
     def handle_gps(self, msg: NavSatFix):
         self.gps_buffer.append(msg)
@@ -185,19 +192,12 @@ class FilteringNode(Node):
             # drone_orientation=(1.0, 0.0, 0.0, 0.0)
         )
 
+        # filter to target classes that haven't been confirmed or deployed yet
         filtered_detections = [
             (lat, lon, cls)
             for lat, lon, cls in detections_global
-            if not self._is_near_deployed_location(lat, lon)
+            if cls in self.targets and self.targets[cls]["state"] == "undetected"
         ]
-        ignored_count = len(detections_global) - len(filtered_detections)
-        # if ignored_count > 0:
-            # self.get_logger().info(
-                # f"[DEBUG] Ignored {ignored_count} detections near deployed locations"
-            # )
-
-        # store for later clustering once mission state changes
-        self.global_dets.extend(detections_global)
         
         # Only run 3-frame confirmation during scan state
         if self.state != 'scan':
@@ -209,21 +209,12 @@ class FilteringNode(Node):
         if len(self.frame_history) > 3:
             self.frame_history.pop(0)
 
-        # Rate-limited print of class names in frame window (1/sec)
-        now = time.time()
-        if now - self._last_window_print_time >= 1.0:
-            self._last_window_print_time = now
-            for i, frame_dets in enumerate(self.frame_history):
-                class_names = set(COCO_CLASS_NAMES[int(cls)] for _, _, cls in frame_dets)
-                self.get_logger().info(f"Frame {i}: {class_names}")
-
         # Check for consistent detection across 3 frames
         confirmed_class = self._check_3frame_confirmation()
-        # self.get_logger().info(f"[DEBUG] 3-frame check result: {confirmed_class}, "
-                            #    f"already confirmed: {self.already_confirmed_classes}")
         
-        if confirmed_class is not None and confirmed_class not in self.already_confirmed_classes:
-            self.already_confirmed_classes.add(confirmed_class)
+        # Guard: confirm class is a valid target and still undetected
+        if confirmed_class is not None and confirmed_class in self.targets and self.targets[confirmed_class]["state"] == "undetected":
+            self.targets[confirmed_class]["state"] = "confirmed"
             self.confirmed_pub.publish(Int8(data=int(confirmed_class)))
 
     def _check_3frame_confirmation(self):
@@ -289,14 +280,12 @@ class FilteringNode(Node):
         return None
 
     def deployed_location_callback(self, msg: ObjectLocations):
-        self.deployed_locations.append((msg.latitude, msg.longitude, msg.class_id))
-
-    def _is_near_deployed_location(self, lat: float, lon: float) -> bool:
-        for deployed_lat, deployed_lon, _ in self.deployed_locations:
-            distance = math.sqrt((lat - deployed_lat) ** 2 + (lon - deployed_lon) ** 2)
-            if distance <= self.deployed_ignore_radius_deg:
-                return True
-        return False
+        # Mark target as deployed and store its final location
+        cls = msg.class_id
+        if cls in self.targets:
+            self.targets[cls]["state"] = "deployed"
+            self.targets[cls]["lat"] = msg.latitude
+            self.targets[cls]["lon"] = msg.longitude
 
     def mission_state_callback(self, msg: String):
         if msg.data != self.prev_state:
@@ -307,14 +296,18 @@ class FilteringNode(Node):
                 self.frame_history.clear()
 
             if msg.data == 'scan':
-                self.already_confirmed_classes.clear()
+                # Reset non-deployed targets so they can be re-detected
+                for cls in self.targets:
+                    if self.targets[cls]["state"] != "deployed":
+                        self.targets[cls]["state"] = "undetected"
 
             # once we leave the 'scan' state, write deployed locations
             if self.prev_state == 'scan':
                 with open('finalized_object_locations.txt', 'w') as f:
-                        for lat, lon, cls in self.deployed_locations:
-                            class_name = COCO_CLASS_NAMES[int(cls)] if int(cls) >= 0 else "unknown"
-                            f.write(f"{lat:.6f},{lon:.6f},{class_name}\n")
+                        for cls, info in self.targets.items():
+                            if info["state"] == "deployed":
+                                class_name = COCO_CLASS_NAMES[int(cls)] if int(cls) >= 0 else "unknown"
+                                f.write(f"{info['lat']:.6f},{info['lon']:.6f},{class_name}\n")
 
         self.prev_state = msg.data
 

--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -242,7 +242,7 @@ class FilteringNode(Node):
             return None
         
         # For each common class, check spatial proximity
-        PROXIMITY_THRESHOLD_DEG =  0.00005  #5.5 meters maybe can tighten
+        PROXIMITY_THRESHOLD_DEG =  0.0001  #5.5 meters maybe can tighten
         
         for cls in common_classes:
             # Get positions for this class in each frame

--- a/bv_core/filtering_node.py
+++ b/bv_core/filtering_node.py
@@ -242,7 +242,7 @@ class FilteringNode(Node):
             return None
         
         # For each common class, check spatial proximity
-        PROXIMITY_THRESHOLD_DEG =  0.0001  #5.5 meters maybe can tighten
+        PROXIMITY_THRESHOLD_DEG =  0.0001  
         
         for cls in common_classes:
             # Get positions for this class in each frame

--- a/bv_core/localizer.py
+++ b/bv_core/localizer.py
@@ -13,11 +13,6 @@ import rclpy.logging
 from ament_index_python.packages import get_package_share_directory
 from collections import defaultdict, Counter
 
-from rfdetr.util.coco_classes import COCO_CLASSES
-
-# Create 0-indexed list from COCO_CLASSES (detector outputs 0-79, not original COCO IDs)
-COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
-
 
 class Localizer:
     def __init__(self,

--- a/bv_core/mission.py
+++ b/bv_core/mission.py
@@ -44,6 +44,7 @@ from bv_msgs.msg import ObjectLocations
 # Mission configuration
 NUM_OBJECTS_TO_FIND = 4          # Total number of objects to detect and deliver to
 DEPLOY_SERVO_CYCLE_TIME = 5.0    # Seconds per servo state during payload deploy
+CLASS_NAMES = ("person", "tent")
 
 
 # State constants
@@ -240,7 +241,7 @@ class MissionRunner(Node):
         )
         
         # Object detection trigger from filtering_node (confirmed 3-frame detection)
-        # Int8 carries the confirmed COCO class_id
+        # Int8 carries the confirmed semantic class_id.
         self.object_detected_sub = self.create_subscription(
             Int8,
             '/global_obj_dets',
@@ -674,9 +675,15 @@ class MissionRunner(Node):
         """Request object localization from vision node."""
         request = LocalizeObject.Request()
         request.target_class_id = self.confirmed_detection_class_id
+        target_name = (
+            CLASS_NAMES[request.target_class_id]
+            if 0 <= request.target_class_id < len(CLASS_NAMES)
+            else "unknown"
+        )
         
         self.get_logger().info(
-            f"Requesting localization from vision node (target_class_id={request.target_class_id})..."
+            "Requesting localization from vision node "
+            f"(target_class={target_name}({request.target_class_id}))..."
         )
         
         future = self.localize_object_client.call_async(request)
@@ -720,9 +727,14 @@ class MissionRunner(Node):
             deployed_msg.longitude = float(lon)
             deployed_msg.class_id = int(self.current_target_class_id) if self.current_target_class_id is not None else -1
             self.deployed_object_pub.publish(deployed_msg)
+            deployed_class_name = (
+                CLASS_NAMES[deployed_msg.class_id]
+                if 0 <= deployed_msg.class_id < len(CLASS_NAMES)
+                else "unknown"
+            )
             self.get_logger().info(
                 f"Published deployed object location: lat={lat:.6f}, lon={lon:.6f}, "
-                f"class_id={deployed_msg.class_id}"
+                f"class={deployed_class_name}({deployed_msg.class_id})"
             )
 
         self.objects_delivered_count += 1
@@ -860,10 +872,16 @@ class MissionRunner(Node):
         
         self.current_target_coords = (response.latitude, response.longitude, response.altitude)
         self.current_target_class_id = int(response.class_id)
+        class_name = (
+            CLASS_NAMES[int(response.class_id)]
+            if 0 <= int(response.class_id) < len(CLASS_NAMES)
+            else "unknown"
+        )
         
         self.get_logger().info(
             f"Object localized at: lat={response.latitude:.6f}, lon={response.longitude:.6f}, "
-            f"alt={response.altitude:.2f}m (class_id={response.class_id})"
+            f"alt={response.altitude:.2f}m "
+            f"(class={class_name}({response.class_id}))"
         )
         
         # Proceed to delivery
@@ -924,7 +942,7 @@ class MissionRunner(Node):
     def on_object_detected(self, msg: Int8):
         """
         Callback when filtering_node confirms object detection (3 frames).
-        msg.data contains the confirmed COCO class_id.
+        msg.data contains the confirmed semantic class_id.
         Stops the drone, waits for stabilization, then transitions to localization.
         """
         if msg.data < 0:
@@ -935,10 +953,17 @@ class MissionRunner(Node):
         
         if self.is_transitioning:
             return  # Already handling a transition
+
+        target_name = (
+            CLASS_NAMES[int(msg.data)]
+            if 0 <= int(msg.data) < len(CLASS_NAMES)
+            else "unknown"
+        )
         
         self.get_logger().info(
             f"OBJECT CONFIRMED! (#{self.objects_delivered_count + 1}) "
-            "- 3-frame detection confirmed. Stopping to localize..."
+            f"- 3-frame detection confirmed. "
+            f"Target={target_name}({int(msg.data)}). Stopping to localize..."
         )
         
         # Store which class was confirmed so we can tell the localizer

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -16,6 +16,7 @@ import time
 import traceback
 import numpy as np
 import yaml
+import cv2
 
 # ROS2
 import rclpy
@@ -81,6 +82,10 @@ class VisionNode(Node):
         self._init_localizer()
         self._init_services()
         self._start_worker_threads()
+        #index to keep track for image naming convention
+        self.curr_wp = 0
+        self.frame_number = 1
+        os.makedirs("raw_frames", exist_ok=True)
 
     def _load_config(self):
         """Load configuration from vision_params.yaml."""
@@ -311,6 +316,8 @@ class VisionNode(Node):
         
         Sets latest_wp to trigger frame capture in the fetch loop.
         """
+        self.curr_wp = self.curr_wp + 1
+        self.frame_number = 1
         if self.last_wp is not None and msg.wp_seq != self.last_wp:
             self.latest_wp = msg.wp_seq
 
@@ -586,6 +593,10 @@ class VisionNode(Node):
             threshold=self.det_thresh,
             overlap=self.overlap
         )
+        
+        if (self.curr_wp % 2 == 0):
+            cv2.imwrite(f"raw_frames/row_{self.curr_wp // 2 + 1}_{self.frame_number}.jpg", frame)
+            self.frame_number = self.frame_number + 1
 
         # Annotate frame using supervision
         labels = [

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -96,15 +96,16 @@ class VisionNode(Node):
             cfg = yaml.safe_load(f)
 
         # Detection settings
-        self.batch_size = cfg.get('batch_size', 4)
         self.det_thresh = cfg.get('detection_threshold', 0.5)
-        self.resolution = cfg.get('resolution', 560)
         self.num_scan_wp = cfg.get('num_scan_wp', 3)
-        self.overlap = cfg.get('overlap', 100)
         self.capture_interval = float(cfg.get('capture_interval', 1.5e9))
 
         # Detector configuration
         self.detector_type = cfg.get('detector_type', 'ml')
+        self.ml_model_path = cfg.get(
+            'ml_model_path',
+            '/Users/allenthomas/Code/Personal/inference/ltdetr.pt'
+        )
         self.gazebo_bbox_topic = cfg.get('gazebo_bbox_topic', '/camera/bounding_boxes')
 
         # Pipeline configuration
@@ -229,8 +230,7 @@ class VisionNode(Node):
         """Initialize the object detector based on config."""
         self.detector = create_detector(
             detector_type=self.detector_type,
-            batch_size=self.batch_size,
-            resolution=self.resolution,
+            ml_model_path=self.ml_model_path,
             gazebo_bbox_topic=self.gazebo_bbox_topic,
         )
         self.detector.start()
@@ -385,7 +385,6 @@ class VisionNode(Node):
         detections = self.detector.process_frame(
             frame=frame,
             threshold=self.det_thresh,
-            overlap=self.overlap
         )
         
         if len(detections) == 0:
@@ -596,7 +595,6 @@ class VisionNode(Node):
         detections = self.detector.process_frame(
             frame=frame,
             threshold=self.det_thresh,
-            overlap=self.overlap
         )
         
         if (self.curr_wp % 2 == 0):

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -45,12 +45,9 @@ from .localizer import Localizer
 # ROS2 utilities
 from ament_index_python.packages import get_package_share_directory
 
-# Detection utilities
-from rfdetr.util.coco_classes import COCO_CLASSES
 import supervision as sv
 
-# Create 0-indexed list from COCO_CLASSES (detector outputs 0-79, not original COCO IDs)
-COCO_CLASS_NAMES = [COCO_CLASSES[k] for k in sorted(COCO_CLASSES.keys())]
+CLASS_NAMES = ("person", "tent")
 
 
 # Vision Node
@@ -427,7 +424,12 @@ class VisionNode(Node):
 
         target_cls = request.target_class_id
         if target_cls >= 0:
-            self.get_logger().info(f"Localizing object: {COCO_CLASS_NAMES[target_cls]}")
+            target_name = (
+                CLASS_NAMES[target_cls]
+                if target_cls < len(CLASS_NAMES)
+                else "unknown"
+            )
+            self.get_logger().info(f"Localizing object: {target_name}")
         else:
             self.get_logger().info("Localizing: any detected object")
 
@@ -600,7 +602,8 @@ class VisionNode(Node):
 
         # Annotate frame using supervision
         labels = [
-            f"{COCO_CLASS_NAMES[int(class_id)]} {confidence:.2f}"
+            f"{CLASS_NAMES[int(class_id)] if 0 <= int(class_id) < len(CLASS_NAMES) else 'unknown'} "
+            f"{confidence:.2f}"
             for class_id, confidence
             in zip(detections.class_id, detections.confidence)
         ]

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -443,6 +443,9 @@ class VisionNode(Node):
                     f"Requested class {target_cls} not found in frame, "
                     f"available: {[int(c[2]) for c in coords]}"
                 )
+                # Treat this as a localization failure so mission retries
+                # instead of navigating to the wrong target.
+                return response
 
         response.success = True
         response.latitude = coords[0][0]

--- a/config/mission_params.yaml
+++ b/config/mission_params.yaml
@@ -9,7 +9,7 @@
 # MISSION CONFIGURATION
 
 # Number of objects to detect and deliver payloads to
-num_objects: 4
+num_objects: 2
 
 # Takeoff altitude used as anchor for all waypoints
 takeoff_alt: &TAKEOFF 16.2

--- a/config/vision_params.yaml
+++ b/config/vision_params.yaml
@@ -3,16 +3,14 @@
 # ============================================================
 
 # Detection settings
-batch_size: 4
 detection_threshold: 0.5
-resolution: 560
-overlap: 100
 capture_interval: 1.5e9
 estimated_camera_latency: 0.5  # Seconds to pause after stopping before capturing frame
 num_scan_wp: 3
 
 # Detector configuration
-detector_type: "gazebo_bbox"  # Options: "ml" (RF-DETR), "gazebo_bbox" (Gazebo bounding box camera)
+detector_type: "gazebo_bbox"  # Options: "ml" (LightlyTrain LTDETR), "gazebo_bbox" (Gazebo bounding box camera)
+ml_model_path: "ltdetr.pt"  # LTDETR checkpoint path when detector_type is "ml"
 gazebo_bbox_topic: "/camera/bounding_boxes"  # Topic for Gazebo bbox camera (only used when detector_type is "gazebo_bbox")
 
 # ============================================================

--- a/container/Dockerfile.arm
+++ b/container/Dockerfile.arm
@@ -71,11 +71,6 @@ RUN apt-get update && \
     apt-get install -y ros-${ROS_DISTRO}-foxglove-bridge && \
     rm -rf /var/lib/apt/lists/*
 
-
-WORKDIR /
-RUN git clone https://github.com/BuckeyeVertical/rf-detr.git && \
-    pip install --no-cache-dir -e /rf-detr
-
 WORKDIR /bv_ws
 
 # Entrypoint & env

--- a/container/Dockerfile.x86
+++ b/container/Dockerfile.x86
@@ -68,11 +68,6 @@ RUN apt-get update && \
     apt-get install -y ros-${ROS_DISTRO}-foxglove-bridge && \
     rm -rf /var/lib/apt/lists/*
 
-# RF-DETR (cloned one level above bv_ws per README instructions)
-WORKDIR /
-RUN git clone --depth 1 https://github.com/BuckeyeVertical/rf-detr.git && \
-    pip install --no-cache-dir -e /rf-detr
-
 WORKDIR /bv_ws
 
 # Entrypoint & env

--- a/container/requirements.txt
+++ b/container/requirements.txt
@@ -1,5 +1,6 @@
 supervision
-git+https://github.com/BuckeyeVertical/rf-detr.git#egg=rfdetr
+lightly-train
+Pillow
 empy==3.3.4
 pyros-genmsg 
 setuptools==65.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 supervision
 lightly-train
+protobuf>=3.19.6,<4
 Pillow
 empy==3.3.4
 pyros-genmsg 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 supervision
+lightly-train
+Pillow
 empy==3.3.4
 pyros-genmsg 
 setuptools==65.5.1


### PR DESCRIPTION
## Summary
This branch simplifies the filtering pipeline around the actual competition targets, standardizes semantic class IDs across the stack, and swaps the active ML detector from RF-DETR to LTDETR while preserving the old RF-DETR implementation as a backup reference.

## What changed
- Simplified `filtering_node` into a target-state flow for the two competition classes only: `person` and `tent`.
- Replaced the older COCO-oriented / radius-based duplicate suppression path with explicit per-target states: `undetected -> confirmed -> deployed`.
- Kept the 3-frame confirmation logic, but only for tracked target classes that are still eligible to be detected.
- Mark deployed targets permanently ignored for the rest of the mission.
- Standardized semantic class handling across filtering, vision, mission, Gazebo detector integration, and localization/logging (`0 = person`, `1 = tent`).
- Updated the Gazebo bounding-box detector to use the world label IDs directly and ignore non-target labels instead of mapping through legacy COCO IDs.
- Updated `vision_node` localization so if mission requests a specific class and that class is not present in the localization frame, the service fails instead of returning the wrong object.
- Replaced the active `MLDetector` backend with LightlyTrain LTDETR using a configurable `ml_model_path`.
- Preserved the previous RF-DETR detector implementation in `bv_core/detectors/RFDETR_detector.py` for safekeeping / rollback reference.
- Removed RF-DETR from the active runtime dependency path and updated requirements / container setup for LTDETR.
- Made ML-only imports lazy so Gazebo-only usage does not need the LTDETR Python packages installed.
- Updated docs/config to reflect LTDETR and the active detector configuration.

## Why
- The filtering logic was carrying legacy COCO assumptions and more state than we actually need for the current mission.
- The mission only needs to track one `person` target and one `tent` target, so explicit target-state tracking is simpler and easier to reason about.
- Using semantic IDs consistently across sim, vision, filtering, and mission removes class-mapping ambiguity.
- Failing localization when the requested class is absent avoids navigating to and deploying on the wrong object.
- LTDETR is the detector we want to run going forward, so the active ML path now matches the intended inference workflow and model weights.
- Keeping the old RF-DETR file as a backup gives us a low-friction rollback/reference point while still cleaning the active runtime path.
- Lazy ML imports keep the Gazebo path lightweight and avoid forcing LTDETR-specific packages on users who are not using the ML detector.

## Validation
- User-tested in Gazebo: mission ran successfully.
- `python3 -m py_compile` passed for the updated detector/vision modules.
- No full automated ROS integration test suite was run in this branch.

## Notes
- There are expected merge conflicts against `main`, especially in `mission.py`, because `main` has additional resume-scan / loiter-return changes that landed after this branch diverged.
- When resolving conflicts, keep `main`'s loiter-return resume behavior and combine it with this branch's semantic-class / filtering updates.
