### PR TITLE
[codex] Replace rate-based stitch capture with distance-based row gating

### DIFF
--- a/bv_core/stitch_geometry.py
+++ b/bv_core/stitch_geometry.py
@@ -1,0 +1,49 @@
+"""Pure-math helpers for distance-based stitch frame capture.
+
+No ROS dependencies; safe to unit-test standalone.
+"""
+import math
+from typing import Tuple
+
+LatLon = Tuple[float, float]
+
+_EARTH_R = 6378137.0  # WGS-84 semi-major axis (meters)
+
+
+def compute_step_m(frame_width_px: int, fx: float, altitude_m: float, overlap: float) -> float:
+    """Along-track meters between consecutive stitch captures.
+
+    Derived from pinhole camera ground footprint:
+        footprint_m = frame_width_px * altitude_m / fx
+        step_m      = footprint_m * (1 - overlap)
+    """
+    if not (0.0 <= overlap < 1.0):
+        raise ValueError(f"overlap must be in [0, 1); got {overlap}")
+    footprint_m = frame_width_px * altitude_m / fx
+    return footprint_m * (1.0 - overlap)
+
+
+def _ll_to_local_xy(point: LatLon, origin: LatLon) -> Tuple[float, float]:
+    """Equirectangular projection relative to origin. Accurate for short segments."""
+    lat0 = math.radians(origin[0])
+    dlat = math.radians(point[0] - origin[0])
+    dlon = math.radians(point[1] - origin[1])
+    x = _EARTH_R * dlon * math.cos(lat0)   # east
+    y = _EARTH_R * dlat                    # north
+    return x, y
+
+
+def along_track_m(current: LatLon, anchor: LatLon, nxt: LatLon) -> float:
+    """Signed along-track distance of `current` along segment `anchor → nxt`, in meters.
+
+    Negative if `current` is behind the anchor.
+    Projection is onto the segment direction vector; lateral drift is ignored.
+    """
+    cx, cy = _ll_to_local_xy(current, anchor)
+    nx, ny = _ll_to_local_xy(nxt, anchor)
+    seg_len2 = nx * nx + ny * ny
+    if seg_len2 == 0.0:
+        return 0.0
+    seg_len = math.sqrt(seg_len2)
+    # dot(current, seg_unit)
+    return (cx * nx + cy * ny) / seg_len

--- a/bv_core/stitch_geometry.py
+++ b/bv_core/stitch_geometry.py
@@ -33,6 +33,12 @@ def _ll_to_local_xy(point: LatLon, origin: LatLon) -> Tuple[float, float]:
     return x, y
 
 
+def distance_m(a: LatLon, b: LatLon) -> float:
+    """Ground distance between two nearby lat/lon points, in meters."""
+    dx, dy = _ll_to_local_xy(a, b)
+    return math.hypot(dx, dy)
+
+
 def along_track_m(current: LatLon, anchor: LatLon, nxt: LatLon) -> float:
     """Signed along-track distance of `current` along segment `anchor → nxt`, in meters.
 

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -42,7 +42,7 @@ from .detectors import create_detector
 from .pipelines import create_pipeline
 from .localizer import Localizer
 from .mission_logger import MissionLogger
-from .stitch_geometry import along_track_m, compute_step_m
+from .stitch_geometry import along_track_m, compute_step_m, distance_m
 
 # ROS2 utilities
 from ament_index_python.packages import get_package_share_directory
@@ -84,8 +84,7 @@ class VisionNode(Node):
         self._init_localizer()
         self._init_services()
         self._start_worker_threads()
-        #index to keep track for image naming convention
-        self.curr_wp = 0
+        # Index retained for legacy image naming conventions.
         self.frame_number = 1
         os.makedirs("raw_frames", exist_ok=True)
 
@@ -141,6 +140,7 @@ class VisionNode(Node):
             mcfg = yaml.safe_load(f)
         self.scan_points = mcfg.get('scan_points', [])
         self.takeoff_alt = float(mcfg.get('takeoff_alt', 15.24))
+        self.scan_tolerance = float(mcfg.get('Scan_tolerance', 2.0))
 
     def _init_state(self):
         """Initialize state tracking variables."""
@@ -163,11 +163,13 @@ class VisionNode(Node):
             altitude_m=self.takeoff_alt,
             overlap=self.stitch_overlap,
         )
-        self.row_anchor_ll = None   # (lat, lon) of current row anchor, or None
-        self.row_next_ll = None     # (lat, lon) of segment endpoint
+        self.row_anchor_ll = None   # (lat, lon) of active row anchor, or None
+        self.row_next_ll = None     # (lat, lon) of active row endpoint
         self.next_capture_m = 0.0
         self.col_idx = 1
         self.raw_frames_cleared = False
+        self.curr_wp = -1
+        self.stitch_paused = False
         self.get_logger().info(
             f"Stitch capture: step_m={self.step_m:.2f} "
             f"(overlap={self.stitch_overlap}, alt={self.takeoff_alt}, fx={fx:.1f})"
@@ -358,17 +360,31 @@ class VisionNode(Node):
         whether we're in 'scan' or 'localize' state.
         """
         new_state = msg.data
+        leaving_scan_mid_row = (
+            self.prev_state == 'scan'
+            and new_state != 'scan'
+            and self.row_anchor_ll is not None
+            and self.row_next_ll is not None
+            and self.curr_wp % 2 == 0
+        )
 
         if new_state == self.prev_state:
             return
 
         self.state = new_state
+        if self.prev_state == 'scan' and new_state != 'scan':
+            self.stitch_paused = leaving_scan_mid_row
 
         # Keep pipeline running in both scan and localize states
         if new_state in ('scan', 'localize'):
             if new_state == 'scan' and not self.raw_frames_cleared:
                 self._clear_raw_frames_dir()
                 self.raw_frames_cleared = True
+            if (new_state == 'scan'
+                    and self.row_anchor_ll is None
+                    and self.curr_wp + 1 >= len(self.scan_points)):
+                self.curr_wp = -1
+                self.stitch_paused = False
             self._start_scanning()
         else:
             self._stop_scanning()
@@ -378,27 +394,45 @@ class VisionNode(Node):
     def _on_waypoint_reached(self, msg: WaypointReached):
         """Handle waypoint reached notifications.
 
-        Advances curr_wp, latches the long-side row anchor on even waypoints,
-        and clears the anchor on odd waypoints (end of row).
+        Advances scan progress only when the next planned scan waypoint is reached,
+        latches the long-side row anchor on even waypoints, and clears the anchor
+        on odd waypoints (end of row).
         """
-        self.curr_wp = self.curr_wp + 1
         self.frame_number = 1  # retained for any legacy consumers
         if self.last_wp is not None and msg.wp_seq != self.last_wp:
             self.latest_wp = msg.wp_seq
         self.last_wp = msg.wp_seq
 
-        # Stitch row tracking: even curr_wp = entry to long-side row
-        if self.state != 'scan':
+        # Stitch row tracking only advances on planned scan waypoints.
+        if self.state != 'scan' or len(self.gps_buffer) == 0:
             return
+
+        next_scan_idx = self.curr_wp + 1
+        if next_scan_idx >= len(self.scan_points):
+            return
+
+        g = self.gps_buffer[-1]
+        current_ll = (g.latitude, g.longitude)
+        expected_scan_ll = (
+            float(self.scan_points[next_scan_idx][0]),
+            float(self.scan_points[next_scan_idx][1]),
+        )
+
+        # Ignore non-scan waypoints, such as the prepended loiter return point on resume.
+        if distance_m(current_ll, expected_scan_ll) > self.scan_tolerance:
+            if self.stitch_paused:
+                self.stitch_paused = False
+                self.get_logger().info(
+                    "Stitch capture resumed after return waypoint; continuing active row"
+                )
+            return
+
+        self.curr_wp = next_scan_idx
+        self.stitch_paused = False
 
         if self.curr_wp % 2 == 0 and self.curr_wp + 1 < len(self.scan_points):
             # Anchor at current GPS (drone is at scan_points[curr_wp]); next is scan_points[curr_wp+1]
-            if len(self.gps_buffer) > 0:
-                g = self.gps_buffer[-1]
-                self.row_anchor_ll = (g.latitude, g.longitude)
-            else:
-                sp = self.scan_points[self.curr_wp]
-                self.row_anchor_ll = (float(sp[0]), float(sp[1]))
+            self.row_anchor_ll = current_ll
             sp_next = self.scan_points[self.curr_wp + 1]
             self.row_next_ll = (float(sp_next[0]), float(sp_next[1]))
             self.col_idx = 1
@@ -408,9 +442,10 @@ class VisionNode(Node):
                 f"anchor={self.row_anchor_ll}, next={self.row_next_ll}"
             )
         else:
-            # Odd curr_wp or past the scan plan: row complete
+            # Odd curr_wp or past the scan plan: row complete.
             self.row_anchor_ll = None
             self.row_next_ll = None
+            self.stitch_paused = False
 
     def _on_timer(self):
         """
@@ -727,6 +762,7 @@ class VisionNode(Node):
                 and self.row_anchor_ll is not None
                 and self.row_next_ll is not None
                 and self.curr_wp % 2 == 0
+                and not self.stitch_paused
                 and len(self.gps_buffer) > 0):
             g = self.gps_buffer[-1]
             d = along_track_m(

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -42,6 +42,7 @@ from .detectors import create_detector
 from .pipelines import create_pipeline
 from .localizer import Localizer
 from .mission_logger import MissionLogger
+from .stitch_geometry import along_track_m, compute_step_m
 
 # ROS2 utilities
 from ament_index_python.packages import get_package_share_directory
@@ -126,6 +127,21 @@ class VisionNode(Node):
         self.record_video = cfg.get('record_video', False)
         self.ros_image_topic = cfg.get('ros_image_topic', '/image_compressed')
 
+        # Stitching capture
+        self.stitch_overlap = float(cfg.get('stitch_overlap', 0.35))
+        self.frame_width_px = int(cfg.get('frame_width_px', 4640))
+
+        # Scan waypoints + takeoff altitude come from mission_params.yaml
+        mission_yaml = os.path.join(
+            get_package_share_directory('bv_core'),
+            'config',
+            'mission_params.yaml'
+        )
+        with open(mission_yaml, 'r') as f:
+            mcfg = yaml.safe_load(f)
+        self.scan_points = mcfg.get('scan_points', [])
+        self.takeoff_alt = float(mcfg.get('takeoff_alt', 15.24))
+
     def _init_state(self):
         """Initialize state tracking variables."""
         self.prev_state = ""
@@ -138,6 +154,36 @@ class VisionNode(Node):
         self.gps_buffer = deque(maxlen=200)
         self.pose_buffer = deque(maxlen=200)
         self.last_rel_alt = None
+
+        # Stitch capture state
+        fx = self._read_fx_from_filtering_yaml()
+        self.step_m = compute_step_m(
+            frame_width_px=self.frame_width_px,
+            fx=fx,
+            altitude_m=self.takeoff_alt,
+            overlap=self.stitch_overlap,
+        )
+        self.row_anchor_ll = None   # (lat, lon) of current row anchor, or None
+        self.row_next_ll = None     # (lat, lon) of segment endpoint
+        self.next_capture_m = 0.0
+        self.col_idx = 1
+        self.raw_frames_cleared = False
+        self.get_logger().info(
+            f"Stitch capture: step_m={self.step_m:.2f} "
+            f"(overlap={self.stitch_overlap}, alt={self.takeoff_alt}, fx={fx:.1f})"
+        )
+
+    def _read_fx_from_filtering_yaml(self) -> float:
+        """Read fx (c_matrix[0]) from filtering_params.yaml."""
+        filtering_yaml = os.path.join(
+            get_package_share_directory('bv_core'),
+            'config',
+            'filtering_params.yaml'
+        )
+        with open(filtering_yaml, 'r') as f:
+            cfg = yaml.safe_load(f)
+        c_mat = cfg.get('c_matrix', [1.0] * 9)
+        return float(c_mat[0])
 
     def _init_pipeline(self):
         """Initialize the camera pipeline based on configuration."""

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -185,6 +185,21 @@ class VisionNode(Node):
         c_mat = cfg.get('c_matrix', [1.0] * 9)
         return float(c_mat[0])
 
+    def _clear_raw_frames_dir(self):
+        """Delete all files in raw_frames/ at first SCAN entry per mission."""
+        raw_dir = "raw_frames"
+        if not os.path.isdir(raw_dir):
+            os.makedirs(raw_dir, exist_ok=True)
+            return
+        for name in os.listdir(raw_dir):
+            path = os.path.join(raw_dir, name)
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+            except OSError as e:
+                self.get_logger().warn(f"Could not remove {path}: {e}")
+        self.get_logger().info("Cleared raw_frames/ for new mission")
+
     def _init_pipeline(self):
         """Initialize the camera pipeline based on configuration."""
         self.pipeline, self.pipeline_topic = create_pipeline(
@@ -351,6 +366,9 @@ class VisionNode(Node):
 
         # Keep pipeline running in both scan and localize states
         if new_state in ('scan', 'localize'):
+            if new_state == 'scan' and not self.raw_frames_cleared:
+                self._clear_raw_frames_dir()
+                self.raw_frames_cleared = True
             self._start_scanning()
         else:
             self._stop_scanning()
@@ -704,9 +722,27 @@ class VisionNode(Node):
             threshold=self.det_thresh,
         )
         
-        if (self.curr_wp % 2 == 0):
-            cv2.imwrite(f"raw_frames/row_{self.curr_wp // 2 + 1}_{self.frame_number}.jpg", frame)
-            self.frame_number = self.frame_number + 1
+        # Distance-based stitching capture (long-side rows only).
+        if (self.state == 'scan'
+                and self.row_anchor_ll is not None
+                and self.row_next_ll is not None
+                and self.curr_wp % 2 == 0
+                and len(self.gps_buffer) > 0):
+            g = self.gps_buffer[-1]
+            d = along_track_m(
+                (g.latitude, g.longitude),
+                self.row_anchor_ll,
+                self.row_next_ll,
+            )
+            if d >= self.next_capture_m:
+                row_n = (self.curr_wp // 2) + 1
+                path = f"raw_frames/row{row_n}_{self.col_idx}.jpg"
+                cv2.imwrite(path, frame)
+                self.get_logger().info(
+                    f"Stitch capture: {path} (d={d:.2f}m, target={self.next_capture_m:.2f}m)"
+                )
+                self.col_idx += 1
+                self.next_capture_m += self.step_m
 
         # Log to mission logger
         if len(detections) > 0:

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -391,7 +391,7 @@ class VisionNode(Node):
         if self.state != 'scan':
             return
 
-        if self.curr_wp % 2 == 0 and self.curr_wp + 1 <= len(self.scan_points):
+        if self.curr_wp % 2 == 0 and self.curr_wp + 1 < len(self.scan_points):
             # Anchor at current GPS (drone is at scan_points[curr_wp]); next is scan_points[curr_wp+1]
             if len(self.gps_buffer) > 0:
                 g = self.gps_buffer[-1]

--- a/bv_core/vision_node.py
+++ b/bv_core/vision_node.py
@@ -358,17 +358,41 @@ class VisionNode(Node):
         self.prev_state = new_state
 
     def _on_waypoint_reached(self, msg: WaypointReached):
-        """
-        Handle waypoint reached notifications.
-        
-        Sets latest_wp to trigger frame capture in the fetch loop.
+        """Handle waypoint reached notifications.
+
+        Advances curr_wp, latches the long-side row anchor on even waypoints,
+        and clears the anchor on odd waypoints (end of row).
         """
         self.curr_wp = self.curr_wp + 1
-        self.frame_number = 1
+        self.frame_number = 1  # retained for any legacy consumers
         if self.last_wp is not None and msg.wp_seq != self.last_wp:
             self.latest_wp = msg.wp_seq
-
         self.last_wp = msg.wp_seq
+
+        # Stitch row tracking: even curr_wp = entry to long-side row
+        if self.state != 'scan':
+            return
+
+        if self.curr_wp % 2 == 0 and self.curr_wp + 1 <= len(self.scan_points):
+            # Anchor at current GPS (drone is at scan_points[curr_wp]); next is scan_points[curr_wp+1]
+            if len(self.gps_buffer) > 0:
+                g = self.gps_buffer[-1]
+                self.row_anchor_ll = (g.latitude, g.longitude)
+            else:
+                sp = self.scan_points[self.curr_wp]
+                self.row_anchor_ll = (float(sp[0]), float(sp[1]))
+            sp_next = self.scan_points[self.curr_wp + 1]
+            self.row_next_ll = (float(sp_next[0]), float(sp_next[1]))
+            self.col_idx = 1
+            self.next_capture_m = self.step_m
+            self.get_logger().info(
+                f"Stitch row entry: curr_wp={self.curr_wp}, "
+                f"anchor={self.row_anchor_ll}, next={self.row_next_ll}"
+            )
+        else:
+            # Odd curr_wp or past the scan plan: row complete
+            self.row_anchor_ll = None
+            self.row_next_ll = None
 
     def _on_timer(self):
         """

--- a/config/vision_params.yaml
+++ b/config/vision_params.yaml
@@ -8,6 +8,10 @@ capture_interval: 1.5e9
 estimated_camera_latency: 0.5  # Seconds to pause after stopping before capturing frame
 num_scan_wp: 3
 
+# Stitching frame capture
+stitch_overlap: 0.35     # Horizontal overlap fraction between consecutive frames in a row
+frame_width_px: 4640     # Camera frame width used for ground-footprint math; must match gst_pipeline
+
 # Detector configuration
 detector_type: "ml"  # Options: "ml" (LightlyTrain LTDETR), "gazebo_bbox" (Gazebo bounding box camera)
 ml_model_path: "ltdetr.pt"  # LTDETR checkpoint path when detector_type is "ml"

--- a/test/test_stitch_geometry.py
+++ b/test/test_stitch_geometry.py
@@ -1,0 +1,52 @@
+"""Unit tests for stitch_geometry helpers."""
+import math
+import pytest
+
+from bv_core.stitch_geometry import along_track_m, compute_step_m
+
+
+def test_compute_step_m_35_percent_overlap():
+    # fx=3582.9, width=4640, altitude=15.24 → footprint ~19.74m, step ~12.83m
+    step = compute_step_m(frame_width_px=4640, fx=3582.9, altitude_m=15.24, overlap=0.35)
+    assert step == pytest.approx(12.83, abs=0.02)
+
+
+def test_compute_step_m_zero_overlap_equals_footprint():
+    step = compute_step_m(frame_width_px=4640, fx=3582.9, altitude_m=15.24, overlap=0.0)
+    footprint = 4640 * 15.24 / 3582.9
+    assert step == pytest.approx(footprint, abs=1e-6)
+
+
+def test_along_track_point_at_anchor_is_zero():
+    anchor = (40.159520, -83.197420)
+    nxt = (40.159520, -83.196820)
+    d = along_track_m(anchor, anchor, nxt)
+    assert d == pytest.approx(0.0, abs=0.01)
+
+
+def test_along_track_point_at_endpoint_equals_segment_length():
+    # Segment: 40.159520,-83.197420 → 40.159520,-83.196820 (pure east, same lat)
+    anchor = (40.159520, -83.197420)
+    nxt = (40.159520, -83.196820)
+    d = along_track_m(nxt, anchor, nxt)
+    # 0.0006 degrees longitude at lat 40.159520 ~ 51.06m
+    assert d == pytest.approx(51.06, abs=0.5)
+
+
+def test_along_track_ignores_lateral_offset():
+    # Drone drifted 5m north of the east-west segment — along-track should still track progress
+    anchor = (40.159520, -83.197420)
+    nxt = (40.159520, -83.196820)
+    # +5m north ≈ +4.49e-5 degrees latitude
+    drifted = (40.159520 + 4.49e-5, -83.197120)  # halfway along the segment, drifted north
+    d = along_track_m(drifted, anchor, nxt)
+    assert d == pytest.approx(25.53, abs=1.0)
+
+
+def test_along_track_negative_before_anchor():
+    anchor = (40.159520, -83.197420)
+    nxt = (40.159520, -83.196820)
+    # A bit west of anchor
+    behind = (40.159520, -83.197500)
+    d = along_track_m(behind, anchor, nxt)
+    assert d < 0.0

--- a/test/test_stitch_geometry.py
+++ b/test/test_stitch_geometry.py
@@ -1,8 +1,7 @@
 """Unit tests for stitch_geometry helpers."""
-import math
 import pytest
 
-from bv_core.stitch_geometry import along_track_m, compute_step_m
+from bv_core.stitch_geometry import along_track_m, compute_step_m, distance_m
 
 
 def test_compute_step_m_35_percent_overlap():
@@ -50,3 +49,9 @@ def test_along_track_negative_before_anchor():
     behind = (40.159520, -83.197500)
     d = along_track_m(behind, anchor, nxt)
     assert d < 0.0
+
+
+def test_distance_m_matches_short_east_west_segment():
+    a = (40.159520, -83.197420)
+    b = (40.159520, -83.196820)
+    assert distance_m(a, b) == pytest.approx(51.06, abs=0.5)


### PR DESCRIPTION
## Summary
This PR replaces the old rate-based stitch frame capture with distance-based capture along each scan row so raw stitch imagery is collected at predictable spacing.

It adds pure geometry helpers to compute the ground step size from camera intrinsics, frame width, takeoff altitude, and desired overlap, then uses live GPS progress along the active row segment to decide when to save each frame.

It also updates the scan-row bookkeeping so stitching survives detection deviations correctly: the active row state is preserved across `LOCALIZE` / `DELIVER` / `DEPLOY`, stitch writes are paused while the aircraft leaves the row, and capture resumes after the return waypoint without treating that loiter-return leg as scan progress.

The change also loads the stitch capture configuration from `vision_params.yaml`, clears `raw_frames/` once at scan start, and adds unit coverage for the geometry helpers.

## Why
The previous time/rate-based capture logic could produce uneven stitch spacing as vehicle speed changed during a pass. That makes downstream mosaicking less reliable and the overlap between adjacent frames harder to control.

Detection-triggered mission deviations also created a stitching gap: without preserving row state and pausing writes during the detour, the node could either lose the rest of the interrupted row or save off-row frames while returning.

Distance gating tied to along-track motion keeps overlap closer to the configured target, and the new pause/resume behavior lets the mission continue stitching the same S-pattern row after a localization/delivery interruption.

## Impact
Detection confirmation, localization, and deployment flow are unchanged. The behavior change is confined to stitch bookkeeping and raw-frame write gating.

## Validation
- `PYTHONPATH=. pytest -q test/test_stitch_geometry.py`
